### PR TITLE
Set VS debug environement for F5 deploy of plugin under test

### DIFF
--- a/XamlStyler.Package/XamlStyler.Package.csproj
+++ b/XamlStyler.Package/XamlStyler.Package.csproj
@@ -25,6 +25,9 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <StartAction>Program</StartAction>
+    <StartProgram>$(DevEnvDir)\devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix Exp</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
As title suggests, this allows F5 debugging of plugin into dev instance of VS.