### PR TITLE
Search for XamlStyler settings file in parent folders

### DIFF
--- a/XamlStyler.Core/Options/StylerOptions.cs
+++ b/XamlStyler.Core/Options/StylerOptions.cs
@@ -309,6 +309,17 @@ namespace Xavalon.XamlStyler.Core.Options
             }
         }
 
+        /// <summary>
+        /// Creates a clone from the current instance.
+        /// </summary>
+        /// <returns>A clone from the current instance.</returns>
+        public IStylerOptions Clone()
+        {
+            var jsonStylerOptions = JsonConvert.SerializeObject(this);
+
+            return JsonConvert.DeserializeObject<StylerOptions>(jsonStylerOptions);
+        }
+
         private void InitializeProperties()
         {
             if (!this.TryLoadExternalConfiguration())

--- a/XamlStyler.Package/StylerPackage.cs
+++ b/XamlStyler.Package/StylerPackage.cs
@@ -173,9 +173,6 @@ namespace Xavalon.XamlStyler.Package
 
             var stylerOptions = GetDialogPage(typeof(PackageOptions)).AutomationObject as IStylerOptions;
 
-            stylerOptions.IndentSize = Int32.Parse(xamlEditorProps.Item("IndentSize").Value.ToString());
-            stylerOptions.IndentWithTabs = (bool)xamlEditorProps.Item("InsertTabs").Value;
-
             var solutionPath = string.IsNullOrEmpty(_dte.Solution?.FullName) ? string.Empty : Path.GetDirectoryName(_dte.Solution.FullName);
             var configPath = GetConfigPathForItem(document.Path, solutionPath);
 
@@ -185,6 +182,9 @@ namespace Xavalon.XamlStyler.Package
 
                 stylerOptions.ConfigPath = configPath;
             }
+
+            stylerOptions.IndentSize = Int32.Parse(xamlEditorProps.Item("IndentSize").Value.ToString());
+            stylerOptions.IndentWithTabs = (bool)xamlEditorProps.Item("InsertTabs").Value;
 
             StylerService styler = new StylerService(stylerOptions);
 

--- a/XamlStyler.Package/StylerPackage.cs
+++ b/XamlStyler.Package/StylerPackage.cs
@@ -181,6 +181,8 @@ namespace Xavalon.XamlStyler.Package
 
             if (configPath != null)
             {
+                stylerOptions = ((StylerOptions)stylerOptions).Clone();
+
                 stylerOptions.ConfigPath = configPath;
             }
 

--- a/XamlStyler.Package/StylerPackage.cs
+++ b/XamlStyler.Package/StylerPackage.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Xavalon.XamlStyler.Core;
@@ -175,6 +176,13 @@ namespace Xavalon.XamlStyler.Package
             stylerOptions.IndentSize = Int32.Parse(xamlEditorProps.Item("IndentSize").Value.ToString());
             stylerOptions.IndentWithTabs = (bool)xamlEditorProps.Item("InsertTabs").Value;
 
+            var configPath = GetConfigPathForItem(document.Path);
+
+            if (configPath != null)
+            {
+                stylerOptions.ConfigPath = configPath;
+            }
+
             StylerService styler = new StylerService(stylerOptions);
 
             var textDocument = (TextDocument)document.Object("TextDocument");
@@ -199,6 +207,32 @@ namespace Xavalon.XamlStyler.Package
             {
                 textDocument.Selection.GotoLine(textDocument.EndPoint.Line);
             }
+        }
+
+        private string GetConfigPathForItem(string path)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(path))
+                {
+                    return null;
+                }
+
+                while ((path = Path.GetDirectoryName(path)) != null)
+                {
+                    var configFile = Path.Combine(path, "Settings.XamlStyler");
+
+                    if (File.Exists(configFile))
+                    {
+                        return configFile;
+                    }
+                }
+            }
+            catch
+            {
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/XamlStyler.Package/StylerPackage.cs
+++ b/XamlStyler.Package/StylerPackage.cs
@@ -176,7 +176,8 @@ namespace Xavalon.XamlStyler.Package
             stylerOptions.IndentSize = Int32.Parse(xamlEditorProps.Item("IndentSize").Value.ToString());
             stylerOptions.IndentWithTabs = (bool)xamlEditorProps.Item("InsertTabs").Value;
 
-            var configPath = GetConfigPathForItem(document.Path);
+            var solutionPath = string.IsNullOrEmpty(_dte.Solution?.FullName) ? string.Empty : Path.GetDirectoryName(_dte.Solution.FullName);
+            var configPath = GetConfigPathForItem(document.Path, solutionPath);
 
             if (configPath != null)
             {
@@ -209,7 +210,7 @@ namespace Xavalon.XamlStyler.Package
             }
         }
 
-        private string GetConfigPathForItem(string path)
+        private string GetConfigPathForItem(string path, string solutionPath)
         {
             try
             {
@@ -218,7 +219,7 @@ namespace Xavalon.XamlStyler.Package
                     return null;
                 }
 
-                while ((path = Path.GetDirectoryName(path)) != null)
+                while ((path = Path.GetDirectoryName(path)) != null && path.StartsWith(solutionPath, StringComparison.InvariantCultureIgnoreCase))
                 {
                     var configFile = Path.Combine(path, "Settings.XamlStyler");
 


### PR DESCRIPTION
The XamlStyler VS Extension will now search for a `Settings.XamlStyler` file on the current folder or one of its parent folders.

This will allow developers to have XamlStyler settings per repo/folder, using the same approach as in .gitignore, StyleCop.Settings, Resharper .DotSettings, etc.