### PR TITLE
Fixed IndentSize handling when setting via configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ XAML Styler is a visual studio extension, which formats XAML source code by sort
 
 [![Join the chat at https://gitter.im/Xavalon/XamlStyler](https://badges.gitter.im/Xavalon/XamlStyler.svg)](https://gitter.im/Xavalon/XamlStyler?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) 
 
-**Thanks to our Contributors:** Bart Lannoeye, Kevin Dockx, Pedro Lamas, Philip Hoppe, and RandomEngy
+[![Build status](https://ci.appveyor.com/api/projects/status/58xlkjm2f1g2w0y1/branch/master?svg=true)](https://ci.appveyor.com/project/grochocki/xamlstyler/branch/master)
+
+**Thanks to our Contributors:** AndrewSt, Bart Lannoeye, Kevin Dockx, Pedro Lamas, Philip Hoppe, and RandomEngy
 
 <sub>This is a fork of the awesome plugin originally created by Chris Chaochen (http://xamlstyler.codeplex.com). To support the efforts Chris has put into this project, this fork will only officially support Visual Studio 2013 and later. For Visual Studio 2012 support please install Chris's version.<sub>

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ XAML Styler is a visual studio extension, which formats XAML source code by sort
 
 **Thanks to our Contributors:** Bart Lannoeye, Kevin Dockx, Pedro Lamas, Philip Hoppe, and RandomEngy
 
-<sub>This is a fork of the awesome plugin originally created by Chris Chaochen (http://xamlstyler.codeplex.com). To support the efforts Chris has put into this project, this fork will only officially support Visual Studio 2013 and later. For Visual Studio 2012 support please install Chris's version.<sub> 
+<sub>This is a fork of the awesome plugin originally created by Chris Chaochen (http://xamlstyler.codeplex.com). To support the efforts Chris has put into this project, this fork will only officially support Visual Studio 2013 and later. For Visual Studio 2012 support please install Chris's version.<sub>

--- a/XamlStyler.Core/Options/DefaultSettings.json
+++ b/XamlStyler.Core/Options/DefaultSettings.json
@@ -38,5 +38,4 @@
     "ThicknessAttributes": "Margin, Padding, BorderThickness, ThumbnailClipMargin",
     "FormatOnSave": true,
     "CommentPadding": 2,
-    "IndentSize": 2
 }

--- a/XamlStyler.Core/Options/IStylerOptions.cs
+++ b/XamlStyler.Core/Options/IStylerOptions.cs
@@ -13,6 +13,8 @@ namespace Xavalon.XamlStyler.Core.Options
 
         int IndentSize { get; set; }
 
+        bool UseVisualStudioIndentSize { get; }
+
         bool IndentWithTabs { get; set; }
 
         #endregion Indentation

--- a/XamlStyler.Package/StylerPackage.cs
+++ b/XamlStyler.Package/StylerPackage.cs
@@ -173,17 +173,27 @@ namespace Xavalon.XamlStyler.Package
 
             var stylerOptions = GetDialogPage(typeof(PackageOptions)).AutomationObject as IStylerOptions;
 
-            var solutionPath = string.IsNullOrEmpty(_dte.Solution?.FullName) ? string.Empty : Path.GetDirectoryName(_dte.Solution.FullName);
+            var solutionPath = String.IsNullOrEmpty(_dte.Solution?.FullName)
+                ? String.Empty
+                : Path.GetDirectoryName(_dte.Solution.FullName);
             var configPath = GetConfigPathForItem(document.Path, solutionPath);
 
             if (configPath != null)
             {
                 stylerOptions = ((StylerOptions)stylerOptions).Clone();
-
                 stylerOptions.ConfigPath = configPath;
             }
 
-            stylerOptions.IndentSize = Int32.Parse(xamlEditorProps.Item("IndentSize").Value.ToString());
+            if (stylerOptions.UseVisualStudioIndentSize)
+            {
+                int outIndentSize;
+                if (Int32.TryParse(xamlEditorProps.Item("IndentSize").Value.ToString(), out outIndentSize)
+                    && (outIndentSize > 0))
+                {
+                    stylerOptions.IndentSize = outIndentSize;
+                }
+            }
+
             stylerOptions.IndentWithTabs = (bool)xamlEditorProps.Item("InsertTabs").Value;
 
             StylerService styler = new StylerService(stylerOptions);

--- a/XamlStyler.UnitTests/TestConfigurations/SerializedDefault.json
+++ b/XamlStyler.UnitTests/TestConfigurations/SerializedDefault.json
@@ -1,4 +1,5 @@
 {
+    "IndentSize":2,
     "AttributeOrderingRuleGroups": [
         "x:Class",
         "xmlns, xmlns:x",

--- a/XamlStyler.UnitTests/TestConfigurations/Single.json
+++ b/XamlStyler.UnitTests/TestConfigurations/Single.json
@@ -1,3 +1,4 @@
 {
+    "IndentSize": 2,
     "AttributesTolerance": 3
 }


### PR DESCRIPTION
@PedroLamas I noticed after merging #46 that if you specify "IndentSize" in an external configuration, it would always be overwritten by VS settings. This change ensures a valid "IndentSize" in an external configuration is respected.