### PR TITLE
Csproj settings fix

### DIFF
--- a/XamlStyler2.Package/StylerPackage.cs
+++ b/XamlStyler2.Package/StylerPackage.cs
@@ -229,10 +229,15 @@ namespace Xavalon.XamlStyler.Package
                     ? String.Empty
                     : Path.GetDirectoryName(_dte.Solution.FullName);
 
+                var projectFullName = _dte.ActiveDocument?.ProjectItem?.ContainingProject?.FullName;
+                var projectDirectory = String.IsNullOrEmpty(projectFullName)
+                    ? String.Empty
+                    : Path.GetDirectoryName(projectFullName);
+
                 IEnumerator<string> configPaths
                     = (path.StartsWith(solutionRoot, StringComparison.InvariantCultureIgnoreCase))
-                        ? StylerPackage.GetConfigPathInsideSolution(path, solutionRoot).GetEnumerator()
-                        : StylerPackage.GetConfigPathOutsideSolution(path).GetEnumerator();
+                        ? StylerPackage.GetConfigPathBetweenPaths(path, solutionRoot).GetEnumerator()
+                        : StylerPackage.GetConfigPathBetweenPaths(path, projectDirectory).GetEnumerator();
 
                 while (configPaths.MoveNext())
                 {
@@ -251,7 +256,7 @@ namespace Xavalon.XamlStyler.Package
         }
 
         // Searches for configuration file up through solution root directory.
-        private static IEnumerable<string> GetConfigPathInsideSolution(string path, string root)
+        private static IEnumerable<string> GetConfigPathBetweenPaths(string path, string root)
         {
             string configDirectory = File.GetAttributes(path).HasFlag(FileAttributes.Directory)
                 ? path
@@ -262,20 +267,6 @@ namespace Xavalon.XamlStyler.Package
                 yield return Path.Combine(configDirectory, "Settings.XamlStyler");
                 configDirectory = Path.GetDirectoryName(configDirectory);
             }
-        }
-
-        // Searches for configuration file up through project root directory.
-        private static IEnumerable<string> GetConfigPathOutsideSolution(string path)
-        {
-            string configDirectory = File.GetAttributes(path).HasFlag(FileAttributes.Directory)
-                ? path
-                : Path.GetDirectoryName(path);
-
-            do
-            {
-                yield return Path.Combine(configDirectory, "Settings.XamlStyler");
-                configDirectory = Path.GetDirectoryName(configDirectory);
-            } while (Directory.GetFiles(configDirectory, "*.csproj").Length == 0);
         }
 
         /// <summary>

--- a/XamlStyler2.Package/StylerPackage.cs
+++ b/XamlStyler2.Package/StylerPackage.cs
@@ -250,12 +250,14 @@ namespace Xavalon.XamlStyler.Package
 
                 configPaths = configPaths.Concat(filePathsInProject);
 
-                var configPathEnumerator = configPaths.GetEnumerator();
-                while (configPathEnumerator.MoveNext())
+                using (var configPathEnumerator = configPaths.GetEnumerator())
                 {
-                    if (File.Exists(configPathEnumerator.Current))
+                    while (configPathEnumerator.MoveNext())
                     {
-                        return configPathEnumerator.Current;
+                        if (File.Exists(configPathEnumerator.Current))
+                        {
+                            return configPathEnumerator.Current;
+                        }
                     }
                 }
             }

--- a/XamlStyler2.Package/StylerPackage.cs
+++ b/XamlStyler2.Package/StylerPackage.cs
@@ -242,13 +242,16 @@ namespace Xavalon.XamlStyler.Package
                         : StylerPackage.GetConfigPathBetweenPaths(path, projectDirectory);
 
                 // find the FullPath of "Settings.XamlStyler" ref in project
-                var filePathsInProject = project.ProjectItems.Cast<ProjectItem>()
+                var filePathsInProject = project?.ProjectItems.Cast<ProjectItem>()
                     .Where(x => string.Equals(x.Name, "Settings.XamlStyler"))
                     .SelectMany(x => x.Properties.Cast<Property>())
                     .Where(x => string.Equals(x.Name, "FullPath"))
                     .Select(x => x.Value as string);
 
-                configPaths = configPaths.Concat(filePathsInProject);
+                if (filePathsInProject != null)
+                {
+                    configPaths = configPaths.Concat(filePathsInProject);
+                }
 
                 using (var configPathEnumerator = configPaths.GetEnumerator())
                 {

--- a/XamlStyler2.Package/StylerPackage.cs
+++ b/XamlStyler2.Package/StylerPackage.cs
@@ -248,7 +248,7 @@ namespace Xavalon.XamlStyler.Package
                     .Where(x => string.Equals(x.Name, "FullPath"))
                     .Select(x => x.Value as string);
 
-                configPaths.Concat(filePathsInProject);
+                configPaths = configPaths.Concat(filePathsInProject);
 
                 var configPathEnumerator = configPaths.GetEnumerator();
                 while (configPathEnumerator.MoveNext())


### PR DESCRIPTION
When the solution file path is not  above the project path, the method `GetConfigPathOutsideSolution` is used and the search stops right before the project directory (which is not what is expected).  
Ex:  
For this code hierarchy:
 * solutionDir
   * MyProject.sln
 * projectDir
   * MyProject.csproj
   * Settings.XamlStyler
   * Views
     * MyView.xaml

The file Settings.XamlStyler is not found, because the method `GetConfigPathOutsideSolution` stops at the "View" directory.
 
To solve this, I replaced the `GetConfigPathOutsideSolution` call with a `GetConfigPathInsideSolution` call (renamed `GetConfigPathBetweenPaths`) with the project path as an argument.

Additionally, I added a lookup inside the project file references so the project can reference the Settings.XamlStyler file outside its "physical" directory.