### PR TITLE
Improves support for inline types

### DIFF
--- a/XamlStyler.Core/DocumentProcessors/ElementDocumentProcessor.cs
+++ b/XamlStyler.Core/DocumentProcessors/ElementDocumentProcessor.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Xml;
 using Xavalon.XamlStyler.Core.Extensions;
@@ -21,6 +22,8 @@ namespace Xavalon.XamlStyler.Core.DocumentProcessors
         private readonly IndentService indentService;
         private readonly IList<string> noNewLineElementsList;
         private readonly IList<string> firstLineAttributes;
+        private readonly string[] inlineCollections = { "TextBlock", "RichTextBlock", "Paragraph", "Span" };
+        private readonly string[] inlineTypes = { "Run", "Hyperlink", "Bold", "Italic", "Underline", "LineBreak", "Paragraph", "Span" };
 
         public ElementDocumentProcessor(
             IStylerOptions options,
@@ -57,8 +60,10 @@ namespace Xavalon.XamlStyler.Core.DocumentProcessors
             // Calculate how element should be indented
             if (!elementProcessContext.Current.IsPreservingSpace)
             {
-                // "Run" get special treatment to try to preserve spacing. Use xml:space='preserve' to make sure!
-                if (elementName.Equals("Run"))
+                // Preserve spacing if element is an inline type has a parent that supports inline types.
+                if ((elementProcessContext.Current.Parent.Name != null)
+                    && this.inlineCollections.Any(elementProcessContext.Current.Parent.Name.Contains)
+                    && this.inlineTypes.Any(elementName.Contains))
                 {
                     elementProcessContext.Current.Parent.IsSignificantWhiteSpace = true;
                     if ((output.Length == 0) || output.IsNewLine())

--- a/XamlStyler.UnitTests/TestFiles/TestRunHandling.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestRunHandling.expected
@@ -60,6 +60,20 @@
         <Run>I</Run> <Run>J</Run>
         <!--  Test2  -->
       </TextBlock>
+      <!--  Additional inline types  -->
+      <TextBlock>
+        <Bold>Bold</Bold><Hyperlink>Hyperlink</Hyperlink><Italic>Italic</Italic><Run>Run</Run><Span>Span</Span><Underline>Underline</Underline><LineBreak /><LineBreak />
+      </TextBlock>
+      <!--  Span  -->
+      <TextBlock>
+        <Span><Bold>Bold</Bold><Hyperlink>Hyperlink</Hyperlink><Italic>Italic</Italic><Run>Run</Run><Underline>Underline</Underline><LineBreak /><LineBreak /></Span>
+      </TextBlock>
+      <!--  RichTextBlock + Paragraph  -->
+      <RichTextBlock>
+        <Paragraph>
+          <Bold>Bold</Bold><Hyperlink>Hyperlink</Hyperlink><Italic>Italic</Italic><Run>Run</Run><Span>Span</Span><Underline>Underline</Underline><LineBreak /><LineBreak />
+        </Paragraph>
+      </RichTextBlock>
     </StackPanel>
   </DockPanel>
 </Window>

--- a/XamlStyler.UnitTests/TestFiles/TestRunHandling.testxaml
+++ b/XamlStyler.UnitTests/TestFiles/TestRunHandling.testxaml
@@ -51,6 +51,20 @@
     <Run>I</Run> <Run>J</Run>
     <!-- Test2 -->
   </TextBlock>
+  <!-- Additional inline types -->
+  <TextBlock>
+    <Bold>Bold</Bold><Hyperlink>Hyperlink</Hyperlink><Italic>Italic</Italic><Run>Run</Run><Span>Span</Span><Underline>Underline</Underline><LineBreak /><LineBreak />
+  </TextBlock>
+  <!-- Span -->
+  <TextBlock>
+    <Span><Bold>Bold</Bold><Hyperlink>Hyperlink</Hyperlink><Italic>Italic</Italic><Run>Run</Run><Underline>Underline</Underline><LineBreak /><LineBreak /></Span>
+  </TextBlock>
+  <!-- RichTextBlock + Paragraph -->
+  <RichTextBlock>
+    <Paragraph>
+      <Bold>Bold</Bold><Hyperlink>Hyperlink</Hyperlink><Italic>Italic</Italic><Run>Run</Run><Span>Span</Span><Underline>Underline</Underline><LineBreak /><LineBreak />
+    </Paragraph>
+  </RichTextBlock>
 </StackPanel>
 </DockPanel>
 </Window>

--- a/XamlStyler.sln
+++ b/XamlStyler.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{913A5DF2-09DC-4155-9BA9-3881B0104F4C}"
 	ProjectSection(SolutionItems) = preProject

--- a/XamlStyler3.Package/XamlStyler3.Package.csproj
+++ b/XamlStyler3.Package/XamlStyler3.Package.csproj
@@ -86,36 +86,36 @@
       <VersionMajor>8</VersionMajor>
       <VersionMinor>0</VersionMinor>
       <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
+      <WrapperTool>tlbimp</WrapperTool>
       <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
     </COMReference>
     <COMReference Include="EnvDTE100">
       <Guid>{26AD1324-4B7C-44BC-84F8-B86AED45729F}</Guid>
       <VersionMajor>10</VersionMajor>
       <VersionMinor>0</VersionMinor>
       <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
+      <WrapperTool>tlbimp</WrapperTool>
       <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
     </COMReference>
     <COMReference Include="EnvDTE80">
       <Guid>{1A31287A-4D7D-413E-8E32-3B374931BD89}</Guid>
       <VersionMajor>8</VersionMajor>
       <VersionMinor>0</VersionMinor>
       <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
+      <WrapperTool>tlbimp</WrapperTool>
       <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
     </COMReference>
     <COMReference Include="EnvDTE90">
       <Guid>{2CE2370E-D744-4936-A090-3FFFE667B0E1}</Guid>
       <VersionMajor>9</VersionMajor>
       <VersionMinor>0</VersionMinor>
       <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
+      <WrapperTool>tlbimp</WrapperTool>
       <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
     </COMReference>
     <COMReference Include="Microsoft.VisualStudio.CommandBars">
       <Guid>{1CBA492E-7263-47BB-87FE-639000619B15}</Guid>


### PR DESCRIPTION
Fixes #81.

Improved handling of Runs, Hyperlinks, Bolds, Italics, Underlines, LineBreaks, Paragraphs, and Spans inside TextBlocks, RichTextBlocks, Spans, and Paragraphs.