### PR TITLE
Add external configuration option to suppress XamlStyler

### DIFF
--- a/XamlStyler.Core/DocumentManipulation/DocumentManipulationService.cs
+++ b/XamlStyler.Core/DocumentManipulation/DocumentManipulationService.cs
@@ -14,6 +14,8 @@ namespace Xavalon.XamlStyler.Core.DocumentManipulation
         private readonly IStylerOptions options;
         private readonly List<IProcessElementService> processElementServices;
 
+        public bool AllowProcessing => !this.options.SuppressProcessing;
+
         public DocumentManipulationService(IStylerOptions options)
         {
             this.options = options;

--- a/XamlStyler.Core/Options/IStylerOptions.cs
+++ b/XamlStyler.Core/Options/IStylerOptions.cs
@@ -107,6 +107,8 @@ namespace Xavalon.XamlStyler.Core.Options
 
         bool ResetToDefault { get; set; }
 
+        bool SuppressProcessing { get; set; }
+
         #endregion Configuration
     }
 }

--- a/XamlStyler.Core/Options/StylerOptions.cs
+++ b/XamlStyler.Core/Options/StylerOptions.cs
@@ -316,6 +316,12 @@ namespace Xavalon.XamlStyler.Core.Options
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [JsonProperty("SuppressProcessing", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [DefaultValue(false)]
+        [Browsable(false)]
+        public bool SuppressProcessing { get; set; }
+
         /// <summary>
         /// Creates a clone from the current instance.
         /// </summary>

--- a/XamlStyler.Core/StylerService.cs
+++ b/XamlStyler.Core/StylerService.cs
@@ -64,20 +64,27 @@ namespace Xavalon.XamlStyler.Core
         /// <returns></returns>
         public string StyleDocument(string xamlSource)
         {
-            // Escape all xml entity references to ensure that they are output exactly as given.
-            var escapedDocument = this.xmlEscapingService.EscapeDocument(xamlSource);
+            string xamlOutput = xamlSource;
 
-            // Parse XDocument.
-            var xDocument = XDocument.Parse(escapedDocument, LoadOptions.PreserveWhitespace);
+            if (this.documentManipulationService.AllowProcessing)
+            {
+                // Escape all xml entity references to ensure that they are output exactly as given.
+                var escapedDocument = this.xmlEscapingService.EscapeDocument(xamlSource);
 
-            // Manipulate the document tree.
-            var manipulatedDocument = this.documentManipulationService.ManipulateDocument(xDocument);
+                // Parse XDocument.
+                var xDocument = XDocument.Parse(escapedDocument, LoadOptions.PreserveWhitespace);
 
-            // Format it to a string.
-            var format = this.Format(manipulatedDocument);
+                // Manipulate the document tree.
+                var manipulatedDocument = this.documentManipulationService.ManipulateDocument(xDocument);
 
-            // Restore escaped xml entity references.
-            return this.xmlEscapingService.UnescapeDocument(format);
+                // Format it to a string.
+                var format = this.Format(manipulatedDocument);
+
+                // Restore escaped xml entity references.
+                xamlOutput = this.xmlEscapingService.UnescapeDocument(format);
+            }
+
+            return xamlOutput;
         }
 
         private string Format(string xamlSource)

--- a/XamlStyler.UnitTests/FileHandlingIntegrationTests.cs
+++ b/XamlStyler.UnitTests/FileHandlingIntegrationTests.cs
@@ -97,6 +97,18 @@ namespace Xavalon.XamlStyler.UnitTests
         }
 
         [Test]
+        public void TestSuppressedDefaultHandling()
+        {
+            var stylerOptions = new StylerOptions(
+                config: this.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
+            {
+                SuppressProcessing = true
+            };
+
+            this.DoTest(stylerOptions);
+        }
+
+        [Test]
         public void TestAttributeSortingOptionHandling()
         {
             var stylerOptions = new StylerOptions(

--- a/XamlStyler.UnitTests/TestFiles/TestSuppressedDefaultHandling.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestSuppressedDefaultHandling.expected
@@ -1,0 +1,92 @@
+﻿<Window x:Class="MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="WPF3D"
+        Width="534"
+        Height="254">
+    <Grid>
+        <!--  Attribute Value With XML Character Entities, e.g., &#10;  -->
+        <TextBlock Text="Some&#10;&amp;&gt;&lt;&quot;' Text" />
+
+        <!--
+            For SL bug: http://devlicio.us/blogs/derik_whittaker/archive/2011/11/29/runtime-exception-for-pageindex-of-a-datapage.aspx
+            To make sure PageSource will be put before PageIndex after formated.
+        -->
+        <DataPager PageSource="{Binding .}" PageIndex="3" />
+
+        <DockPanel Grid.Row="0"
+                   Grid.RowSpan="1"
+                   Grid.Column="0"
+                   Grid.ColumnSpan="1"
+                   Width="Auto"
+                   Height="Auto"
+                   Margin="0,0,0,0"
+                   HorizontalAlignment="Stretch"
+                   VerticalAlignment="Stretch">
+            <StackPanel>
+                <StackPanel.Background>
+                    <LinearGradientBrush>
+                        <GradientStop Offset="0" Color="White" />
+                        <GradientStop Offset=".3" Color="DarkKhaki" />
+                        <GradientStop Offset=".7" Color="DarkKhaki" />
+                        <GradientStop Offset="1" Color="White" />
+                    </LinearGradientBrush>
+                </StackPanel.Background>
+                <StackPanel Margin="10">
+                    <TextBlock Text="Camera X Position:" />
+                    <TextBox Name="cameraPositionXTextBox"
+                             HorizontalAlignment="Left"
+                             MaxLength="5"
+                             Text="9" />
+                    <TextBlock Text="Camera Y Position:" />
+                    <TextBox Name="cameraPositionYTextBox"
+                             HorizontalAlignment="Left"
+                             MaxLength="5"
+                             Text="8" />
+                    <TextBlock Text="Camera Z Position:" />
+                    <TextBox Name="cameraPositionZTextBox"
+                             HorizontalAlignment="Left"
+                             MaxLength="5"
+                             Text="10" />
+                    <Separator />
+                    <TextBlock Text="Look Direction X:" />
+                    <TextBox Name="lookAtXTextBox"
+                             HorizontalAlignment="Left"
+                             MaxLength="5"
+                             Text="-9" />
+                    <TextBlock Text="Look Direction Y:" />
+                    <TextBox Name="lookAtYTextBox"
+                             HorizontalAlignment="Left"
+                             MaxLength="5"
+                             Text="-8" />
+                    <TextBlock Text="Look Direction Z:" />
+                    <TextBox Name="lookAtZTextBox"
+                             HorizontalAlignment="Left"
+                             MaxLength="5"
+                             Text="-10" />
+                    <Separator />
+
+                    <Button Name="simpleButton" Click="simpleButtonClick">Simple</Button>
+                    <Button Name="cubeButton" Click="cubeButtonClick">Cube</Button>
+                </StackPanel>
+            </StackPanel>
+            <!--#region This is a ViewPort-->
+            <Viewport3D Name="mainViewport" ClipToBounds="True">
+                <Viewport3D.Camera>
+                    <PerspectiveCamera FarPlaneDistance="100"
+                                       FieldOfView="70"
+                                       LookDirection="-11,-10,-9"
+                                       NearPlaneDistance="1"
+                                       Position="11,10,9"
+                                       UpDirection="0,1,0" />
+                </Viewport3D.Camera>
+                <ModelVisual3D>
+                    <ModelVisual3D.Content>
+                        <DirectionalLight Direction="-2,-3,-1" Color="White" />
+                    </ModelVisual3D.Content>
+                </ModelVisual3D>
+            </Viewport3D>
+            <!--#endregion-->
+        </DockPanel>
+    </Grid>
+</Window>

--- a/XamlStyler.UnitTests/TestFiles/TestSuppressedDefaultHandling.testxaml
+++ b/XamlStyler.UnitTests/TestFiles/TestSuppressedDefaultHandling.testxaml
@@ -1,0 +1,92 @@
+﻿<Window x:Class="MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="WPF3D"
+        Width="534"
+        Height="254">
+    <Grid>
+        <!--  Attribute Value With XML Character Entities, e.g., &#10;  -->
+        <TextBlock Text="Some&#10;&amp;&gt;&lt;&quot;' Text" />
+
+        <!--
+            For SL bug: http://devlicio.us/blogs/derik_whittaker/archive/2011/11/29/runtime-exception-for-pageindex-of-a-datapage.aspx
+            To make sure PageSource will be put before PageIndex after formated.
+        -->
+        <DataPager PageSource="{Binding .}" PageIndex="3" />
+
+        <DockPanel Grid.Row="0"
+                   Grid.RowSpan="1"
+                   Grid.Column="0"
+                   Grid.ColumnSpan="1"
+                   Width="Auto"
+                   Height="Auto"
+                   Margin="0,0,0,0"
+                   HorizontalAlignment="Stretch"
+                   VerticalAlignment="Stretch">
+            <StackPanel>
+                <StackPanel.Background>
+                    <LinearGradientBrush>
+                        <GradientStop Offset="0" Color="White" />
+                        <GradientStop Offset=".3" Color="DarkKhaki" />
+                        <GradientStop Offset=".7" Color="DarkKhaki" />
+                        <GradientStop Offset="1" Color="White" />
+                    </LinearGradientBrush>
+                </StackPanel.Background>
+                <StackPanel Margin="10">
+                    <TextBlock Text="Camera X Position:" />
+                    <TextBox Name="cameraPositionXTextBox"
+                             HorizontalAlignment="Left"
+                             MaxLength="5"
+                             Text="9" />
+                    <TextBlock Text="Camera Y Position:" />
+                    <TextBox Name="cameraPositionYTextBox"
+                             HorizontalAlignment="Left"
+                             MaxLength="5"
+                             Text="8" />
+                    <TextBlock Text="Camera Z Position:" />
+                    <TextBox Name="cameraPositionZTextBox"
+                             HorizontalAlignment="Left"
+                             MaxLength="5"
+                             Text="10" />
+                    <Separator />
+                    <TextBlock Text="Look Direction X:" />
+                    <TextBox Name="lookAtXTextBox"
+                             HorizontalAlignment="Left"
+                             MaxLength="5"
+                             Text="-9" />
+                    <TextBlock Text="Look Direction Y:" />
+                    <TextBox Name="lookAtYTextBox"
+                             HorizontalAlignment="Left"
+                             MaxLength="5"
+                             Text="-8" />
+                    <TextBlock Text="Look Direction Z:" />
+                    <TextBox Name="lookAtZTextBox"
+                             HorizontalAlignment="Left"
+                             MaxLength="5"
+                             Text="-10" />
+                    <Separator />
+
+                    <Button Name="simpleButton" Click="simpleButtonClick">Simple</Button>
+                    <Button Name="cubeButton" Click="cubeButtonClick">Cube</Button>
+                </StackPanel>
+            </StackPanel>
+            <!--#region This is a ViewPort-->
+            <Viewport3D Name="mainViewport" ClipToBounds="True">
+                <Viewport3D.Camera>
+                    <PerspectiveCamera FarPlaneDistance="100"
+                                       FieldOfView="70"
+                                       LookDirection="-11,-10,-9"
+                                       NearPlaneDistance="1"
+                                       Position="11,10,9"
+                                       UpDirection="0,1,0" />
+                </Viewport3D.Camera>
+                <ModelVisual3D>
+                    <ModelVisual3D.Content>
+                        <DirectionalLight Direction="-2,-3,-1" Color="White" />
+                    </ModelVisual3D.Content>
+                </ModelVisual3D>
+            </Viewport3D>
+            <!--#endregion-->
+        </DockPanel>
+    </Grid>
+</Window>

--- a/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
+++ b/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
@@ -146,6 +146,12 @@
     <None Include="TestFiles\TestAttributeIndentationHandling_0.expected">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="TestFiles\TestSuppressedDefaultHandling.expected">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestFiles\TestSuppressedDefaultHandling.testxaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="TestFiles\TestNestedCustomMarkupExtensionsWithBindings.testxaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/XamlStyler.sln
+++ b/XamlStyler.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{913A5DF2-09DC-4155-9BA9-3881B0104F4C}"
 	ProjectSection(SolutionItems) = preProject

--- a/XamlStyler3.Package/XamlStyler3.Package.csproj
+++ b/XamlStyler3.Package/XamlStyler3.Package.csproj
@@ -86,36 +86,36 @@
       <VersionMajor>8</VersionMajor>
       <VersionMinor>0</VersionMinor>
       <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
+      <WrapperTool>tlbimp</WrapperTool>
       <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
     </COMReference>
     <COMReference Include="EnvDTE100">
       <Guid>{26AD1324-4B7C-44BC-84F8-B86AED45729F}</Guid>
       <VersionMajor>10</VersionMajor>
       <VersionMinor>0</VersionMinor>
       <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
+      <WrapperTool>tlbimp</WrapperTool>
       <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
     </COMReference>
     <COMReference Include="EnvDTE80">
       <Guid>{1A31287A-4D7D-413E-8E32-3B374931BD89}</Guid>
       <VersionMajor>8</VersionMajor>
       <VersionMinor>0</VersionMinor>
       <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
+      <WrapperTool>tlbimp</WrapperTool>
       <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
     </COMReference>
     <COMReference Include="EnvDTE90">
       <Guid>{2CE2370E-D744-4936-A090-3FFFE667B0E1}</Guid>
       <VersionMajor>9</VersionMajor>
       <VersionMinor>0</VersionMinor>
       <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
+      <WrapperTool>tlbimp</WrapperTool>
       <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
     </COMReference>
     <COMReference Include="Microsoft.VisualStudio.CommandBars">
       <Guid>{1CBA492E-7263-47BB-87FE-639000619B15}</Guid>


### PR DESCRIPTION
Closes #65

Adds "SuppressProcessing" external configuration option to suppress XamlStyler on a per directory/project/solution basis.