### PR TITLE
Fixes #109 (Attributes are randomly reordered under specific conditions)

### DIFF
--- a/XamlStyler.Core/DocumentProcessors/ElementDocumentProcessor.cs
+++ b/XamlStyler.Core/DocumentProcessors/ElementDocumentProcessor.cs
@@ -159,8 +159,13 @@ namespace Xavalon.XamlStyler.Core.DocumentProcessors
 
             if (this.options.EnableAttributeReordering)
             {
-                list.Sort(this.AttributeInfoComparison);
-                firstLineList.Sort(this.AttributeInfoComparison);
+                // .NET performs insertion sort if collection partition size is fewer than 16 elements, but it uses
+                // Heapsort or Quicksort under different conditions. This can lead to an unstable sort and randomized
+                // attributbes while formatting. Even though insertion sort is less performant, XAML elements with more
+                // than 16 attributes are not common, so the effect of forcing insertion sort is negligable in all but
+                // the most extreme of cases. - https://msdn.microsoft.com/en-us/library/b0zbh7b6(v=vs.110).aspx
+                list.InsertionSort(this.AttributeInfoComparison);
+                firstLineList.InsertionSort(this.AttributeInfoComparison);
             }
 
             var noLineBreakInAttributes = (list.Count <= this.options.AttributesTolerance) || isNoLineBreakElement;

--- a/XamlStyler.Core/Extensions/ListExtensions.cs
+++ b/XamlStyler.Core/Extensions/ListExtensions.cs
@@ -1,0 +1,38 @@
+﻿// © Xavalon. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+
+namespace Xavalon.XamlStyler.Core.Extensions
+{
+    public static class ListExtensions
+    {
+        public static void InsertionSort<T>(this IList<T> list, Comparison<T> comparison)
+        {
+            if (list == null)
+            {
+                throw new ArgumentNullException("list");
+            }
+
+            if (comparison == null)
+            {
+                throw new ArgumentNullException("comparison");
+            }
+
+            int count = list.Count;
+
+            for (int j = 1; j < count; j++)
+            {
+                T key = list[j];
+                int i = j - 1;
+
+                for (; (i >= 0) && (comparison(list[i], key) > 0); i--)
+                {
+                    list[i + 1] = list[i];
+                }
+
+                list[i + 1] = key;
+            }
+        }
+    }
+}

--- a/XamlStyler.Core/XamlStyler.Core.csproj
+++ b/XamlStyler.Core/XamlStyler.Core.csproj
@@ -84,6 +84,7 @@
     <Compile Include="DocumentProcessors\IDocumentProcessor.cs" />
     <Compile Include="DocumentProcessors\WhitespaceDocumentProcessor.cs" />
     <Compile Include="DocumentProcessors\XmlDeclarationDocumentProcessor.cs" />
+    <Compile Include="Extensions\ListExtensions.cs" />
     <Compile Include="MarkupExtensions\Formatter\AttributeInfoFactory.cs" />
     <Compile Include="MarkupExtensions\Formatter\MarkupExtensionFormatterBase.cs" />
     <Compile Include="Extensions\XmlReaderExtensions.cs" />


### PR DESCRIPTION
.NET performs insertion sort if collection partition size is fewer than 16 elements, but it uses Heapsort or Quicksort under different conditions. This can lead to an unstable sort and randomized attributbes while formatting. Even though insertion sort is less performant, XAML elements with more than 16 attributes are not common, so the effect of forcing insertion sort is negligable in all but the most extreme of cases ([https://msdn.microsoft.com/en-us/library/b0zbh7b6(v=vs.110).aspx](https://msdn.microsoft.com/en-us/library/b0zbh7b6(v=vs.110).aspx)). Fixes #109.