### PR TITLE
Fixes #94 (Newline exemption elements bug)

### DIFF
--- a/XamlStyler.Core/MarkupExtensions/Formatter/MarkupExtensionFormatter.cs
+++ b/XamlStyler.Core/MarkupExtensions/Formatter/MarkupExtensionFormatter.cs
@@ -25,13 +25,14 @@ namespace Xavalon.XamlStyler.Core.MarkupExtensions.Formatter
         /// Indention from previous element/attribute/tags must be applied separately
         /// </summary>
         /// <param name="markupExtension"></param>
+        /// /// <param name="isNested"></param>
         /// <returns></returns>
-        public IEnumerable<string> Format(MarkupExtension markupExtension)
+        public IEnumerable<string> Format(MarkupExtension markupExtension, bool isNested = false)
         {
-            var formatter = (this.singleLineTypes.Contains(markupExtension.TypeName))
+            var formatter = (isNested || this.singleLineTypes.Contains(markupExtension.TypeName))
                 ? this.singleLineFormatter
                 : this.multiLineFormatter;
-            return formatter.Format(markupExtension);
+            return formatter.FormatArguments(markupExtension, isNested: isNested);
         }
 
         /// <summary>
@@ -41,7 +42,7 @@ namespace Xavalon.XamlStyler.Core.MarkupExtensions.Formatter
         /// <returns></returns>
         public string FormatSingleLine(MarkupExtension markupExtension)
         {
-            return this.singleLineFormatter.Format(markupExtension).Single();
+            return this.singleLineFormatter.FormatArguments(markupExtension).Single();
         }
     }
 }

--- a/XamlStyler.Core/MarkupExtensions/Formatter/MarkupExtensionFormatterBase.cs
+++ b/XamlStyler.Core/MarkupExtensions/Formatter/MarkupExtensionFormatterBase.cs
@@ -16,22 +16,22 @@ namespace Xavalon.XamlStyler.Core.MarkupExtensions.Formatter
             this.markupExtensionFormatter = markupExtensionFormatter;
         }
 
-        public IEnumerable<string> Format(MarkupExtension markupExtension)
+        public IEnumerable<string> FormatArguments(MarkupExtension markupExtension, bool isNested = false)
         {
             return markupExtension.Arguments.Any()
-                ? this.Format($"{{{markupExtension.TypeName} ", this.Format(markupExtension.Arguments), "}")
+                ? this.Format($"{{{markupExtension.TypeName} ", this.FormatArguments(markupExtension.Arguments, isNested: isNested), "}")
                 : new string[] { $"{{{markupExtension.TypeName}}}" };
         }
 
-        protected abstract IEnumerable<string> Format(Argument[] arguments);
+        protected abstract IEnumerable<string> FormatArguments(Argument[] arguments, bool isNested = false);
 
-        protected IEnumerable<string> Format(Argument argument)
+        protected IEnumerable<string> FormatArgument(Argument argument, bool isNested = false)
         {
             var type = argument.GetType();
 
             if (type == typeof(NamedArgument))
             {
-                return this.Format((NamedArgument)argument);
+                return this.FormatNamedArgument((NamedArgument)argument);
             }
 
             if (type == typeof(PositionalArgument))
@@ -40,11 +40,11 @@ namespace Xavalon.XamlStyler.Core.MarkupExtensions.Formatter
 
                 if (positionalArgument.Value.GetType() == typeof(MarkupExtension))
                 {
-                    return this.markupExtensionFormatter.Format((MarkupExtension)positionalArgument.Value);
+                    return this.markupExtensionFormatter.Format((MarkupExtension)positionalArgument.Value, isNested: isNested);
                 }
                 else
                 {
-                    return this.Format(positionalArgument);
+                    return this.FormatPositionalArgument(positionalArgument);
                 }
             }
 
@@ -67,17 +67,17 @@ namespace Xavalon.XamlStyler.Core.MarkupExtensions.Formatter
             return list;
         }
 
-        private IEnumerable<string> Format(NamedArgument namedArgument)
+        private IEnumerable<string> FormatNamedArgument(NamedArgument namedArgument)
         {
-            return this.Format($"{namedArgument.Name}=", this.Format(namedArgument.Value));
+            return this.Format($"{namedArgument.Name}=", this.FormatValue(namedArgument.Value));
         }
 
-        private IEnumerable<string> Format(PositionalArgument positionalArgument)
+        private IEnumerable<string> FormatPositionalArgument(PositionalArgument positionalArgument)
         {
-            return this.Format(positionalArgument.Value);
+            return this.FormatValue(positionalArgument.Value);
         }
 
-        private IEnumerable<string> Format(LiteralValue literalValue)
+        private IEnumerable<string> FormatLiteralValue(LiteralValue literalValue)
         {
             return new[]
             {
@@ -85,18 +85,18 @@ namespace Xavalon.XamlStyler.Core.MarkupExtensions.Formatter
             };
         }
 
-        private IEnumerable<string> Format(Value value)
+        private IEnumerable<string> FormatValue(Value value)
         {
             var type = value.GetType();
 
             if (type == typeof(LiteralValue))
             {
-                return this.Format((LiteralValue)value);
+                return this.FormatLiteralValue((LiteralValue)value);
             }
 
             if (type == typeof(MarkupExtension))
             {
-                return this.Format((MarkupExtension)value);
+                return this.FormatArguments((MarkupExtension)value);
             }
 
             throw new ArgumentException($"Unhandled type {type.FullName}", nameof(value));

--- a/XamlStyler.Core/MarkupExtensions/Formatter/MultiLineMarkupExtensionFormatter.cs
+++ b/XamlStyler.Core/MarkupExtensions/Formatter/MultiLineMarkupExtensionFormatter.cs
@@ -12,7 +12,7 @@ namespace Xavalon.XamlStyler.Core.MarkupExtensions.Formatter
         {
         }
 
-        protected override IEnumerable<string> Format(Argument[] arguments)
+        protected override IEnumerable<string> FormatArguments(Argument[] arguments, bool isNested = false)
         {
             var list = new List<string>();
             string deferred = null;
@@ -23,7 +23,7 @@ namespace Xavalon.XamlStyler.Core.MarkupExtensions.Formatter
                     deferred += ",";
                 }
 
-                foreach (var line in this.Format(argument))
+                foreach (var line in this.FormatArgument(argument, isNested: isNested))
                 {
                     if (deferred != null)
                     {

--- a/XamlStyler.Core/MarkupExtensions/Formatter/SingleLineMarkupExtensionFormatter.cs
+++ b/XamlStyler.Core/MarkupExtensions/Formatter/SingleLineMarkupExtensionFormatter.cs
@@ -13,7 +13,7 @@ namespace Xavalon.XamlStyler.Core.MarkupExtensions.Formatter
         {
         }
 
-        protected override IEnumerable<string> Format(Argument[] arguments)
+        protected override IEnumerable<string> FormatArguments(Argument[] arguments, bool isNested = false)
         {
             StringBuilder stringBuilder = new StringBuilder();
             foreach (var argument in arguments)
@@ -23,7 +23,7 @@ namespace Xavalon.XamlStyler.Core.MarkupExtensions.Formatter
                     stringBuilder.Append(", ");
                 }
 
-                foreach (var line in this.Format(argument))
+                foreach (var line in this.FormatArgument(argument, isNested: true))
                 {
                     stringBuilder.Append(line);
                 }

--- a/XamlStyler.UnitTests/FileHandlingIntegrationTests.cs
+++ b/XamlStyler.UnitTests/FileHandlingIntegrationTests.cs
@@ -201,6 +201,12 @@ namespace Xavalon.XamlStyler.UnitTests
         }
 
         [Test]
+        public void TestSingleLineNestedMarkupExtensions()
+        {
+            this.DoTest(new StylerOptions());
+        }
+
+        [Test]
         public void TestMarkupWithAttributeNotOnFirstLine()
         {
             var stylerOptions = new StylerOptions(

--- a/XamlStyler.UnitTests/TestFiles/TestSingleLineNestedMarkupExtensions.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestSingleLineNestedMarkupExtensions.expected
@@ -1,0 +1,5 @@
+﻿<Window>
+  <Grid>
+    <Setter Property="Template" Value="{DynamicResource {ComponentResourceKey ResourceId=SubmenuItemTemplateKey, TypeInTargetAssembly={x:Type MenuItem}}}" />
+  </Grid>
+</Window>

--- a/XamlStyler.UnitTests/TestFiles/TestSingleLineNestedMarkupExtensions.testxaml
+++ b/XamlStyler.UnitTests/TestFiles/TestSingleLineNestedMarkupExtensions.testxaml
@@ -1,0 +1,7 @@
+﻿<Window>
+  <Grid>
+    <Setter Property="Template"
+            Value="{DynamicResource {ComponentResourceKey ResourceId=SubmenuItemTemplateKey,
+                                                          TypeInTargetAssembly={x:Type MenuItem}}}" />
+  </Grid>
+</Window>

--- a/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
+++ b/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
@@ -146,6 +146,12 @@
     <None Include="TestFiles\TestAttributeIndentationHandling_0.expected">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="TestFiles\TestSingleLineNestedMarkupExtensions.expected">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestFiles\TestSingleLineNestedMarkupExtensions.testxaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="TestFiles\TestSuppressedDefaultHandling.expected">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Fixes #94 (Newline exemption elements bug).
Fixes #99 (Unwanted spaces in nested markup extension).
Cleans up some ambiguous method naming.