### PR TITLE
#137 (closing tags should also respect "Space before ending slash in …

### DIFF
--- a/XamlStyler.Core/DocumentProcessors/ElementDocumentProcessor.cs
+++ b/XamlStyler.Core/DocumentProcessors/ElementDocumentProcessor.cs
@@ -125,6 +125,11 @@ namespace Xavalon.XamlStyler.Core.DocumentProcessors
             }
             else
             {
+                if (this.options.SpaceBeforeClosingSlash && !putEndingBracketOnNewLine && xmlReader.HasAttributes)
+                {
+                    output.Append(' ');
+                }
+
                 output.Append(">");
             }
         }

--- a/XamlStyler.UnitTests/TestFiles/TestAttributeIndentationHandling_0.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestAttributeIndentationHandling_0.expected
@@ -9,7 +9,7 @@
       <Setter Property="Text" Value="Default Text &amp;&lt;" />
       <Style.Triggers>
         <!--  Elements no line break between attributes: "Trigger"  -->
-        <Trigger Property="IsEnabled" Value="false">
+        <Trigger Property="IsEnabled" Value="false" >
           <Setter Property="Background" Value="#EEEEEE" />
         </Trigger>
 

--- a/XamlStyler.UnitTests/TestFiles/TestAttributeIndentationHandling_4.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestAttributeIndentationHandling_4.expected
@@ -9,7 +9,7 @@
       <Setter Property="Text" Value="Default Text &amp;&lt;" />
       <Style.Triggers>
         <!--  Elements no line break between attributes: "Trigger"  -->
-        <Trigger Property="IsEnabled" Value="false">
+        <Trigger Property="IsEnabled" Value="false" >
           <Setter Property="Background" Value="#EEEEEE" />
         </Trigger>
 

--- a/XamlStyler.UnitTests/TestFiles/TestAttributeOrderRuleGroupsOnSeparateLinesHandling.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestAttributeOrderRuleGroupsOnSeparateLinesHandling.expected
@@ -1,13 +1,13 @@
 ﻿<Window x:Class="MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="WPF3D"
-        Width="534" Height="254">
+        Width="534" Height="254" >
   <Window.Resources>
-    <Style TargetType="TextBox">
+    <Style TargetType="TextBox" >
       <Setter Property="Text" Value="Default Text &amp;&lt;" />
       <Style.Triggers>
         <!--  Elements no line break between attributes: "Trigger"  -->
-        <Trigger Property="IsEnabled" Value="false">
+        <Trigger Property="IsEnabled" Value="false" >
           <Setter Property="Background" Value="#EEEEEE" />
         </Trigger>
 
@@ -34,7 +34,7 @@
     <DockPanel Grid.Row="0" Grid.RowSpan="1" Grid.Column="0"
                Grid.ColumnSpan="1"
                Width="Auto" Height="Auto" Margin="0,0,0,0"
-               HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+               HorizontalAlignment="Stretch" VerticalAlignment="Stretch" >
       <StackPanel>
         <StackPanel.Background>
           <LinearGradientBrush>
@@ -44,7 +44,7 @@
             <GradientStop Offset="1" Color="White" />
           </LinearGradientBrush>
         </StackPanel.Background>
-        <StackPanel Margin="10">
+        <StackPanel Margin="10" >
           <TextBlock Text="Camera X Position:" />
           <TextBox Name="cameraPositionXTextBox"
                    HorizontalAlignment="Left"
@@ -72,12 +72,12 @@
                    MaxLength="5" Text="-10" />
           <Separator />
 
-          <Button Name="simpleButton" Click="simpleButtonClick">Simple</Button>
-          <Button Name="cubeButton" Click="cubeButtonClick">Cube</Button>
+          <Button Name="simpleButton" Click="simpleButtonClick" >Simple</Button>
+          <Button Name="cubeButton" Click="cubeButtonClick" >Cube</Button>
         </StackPanel>
       </StackPanel>
       <!--#region This is a ViewPort-->
-      <Viewport3D Name="mainViewport" ClipToBounds="True">
+      <Viewport3D Name="mainViewport" ClipToBounds="True" >
         <Viewport3D.Camera>
           <PerspectiveCamera FarPlaneDistance="100" FieldOfView="70" LookDirection="-11,-10,-9"
                              NearPlaneDistance="1" Position="11,10,9" UpDirection="0,1,0" />

--- a/XamlStyler.UnitTests/TestFiles/TestAttributeSortingOptionHandling.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestAttributeSortingOptionHandling.expected
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="WPF3D"
         Width="534"
-        Height="254">
+        Height="254" >
   <![CDATA[An in-depth look at creating applications with XML, using <, >,]]>
   <Grid>
     <!--  Attribute Value With XML Character Entities, e.g., &#10;  -->
@@ -34,7 +34,7 @@
                Margin="0,0,0,0"
                Panel.ZIndex="1"
                HorizontalAlignment="Stretch"
-               VerticalAlignment="Stretch">
+               VerticalAlignment="Stretch" >
       <StackPanel>
         <StackPanel.Background>
           <LinearGradientBrush>
@@ -44,7 +44,7 @@
             <GradientStop Offset="1" Color="White" />
           </LinearGradientBrush>
         </StackPanel.Background>
-        <StackPanel Margin="10">
+        <StackPanel Margin="10" >
           <TextBlock Text="Camera X Position:" />
           <TextBox Name="cameraPositionXTextBox"
                    HorizontalAlignment="Left"
@@ -78,11 +78,11 @@
                    Text="-10" />
           <Separator />
 
-          <Button Name="simpleButton" Click="simpleButtonClick">Simple</Button>
-          <Button Name="cubeButton" Click="cubeButtonClick">Cube</Button>
+          <Button Name="simpleButton" Click="simpleButtonClick" >Simple</Button>
+          <Button Name="cubeButton" Click="cubeButtonClick" >Cube</Button>
         </StackPanel>
       </StackPanel>
-      <Viewport3D Name="mainViewport" ClipToBounds="True">
+      <Viewport3D Name="mainViewport" ClipToBounds="True" >
         <Viewport3D.Camera>
           <PerspectiveCamera FarPlaneDistance="100"
                              FieldOfView="70"

--- a/XamlStyler.UnitTests/TestFiles/TestAttributeThresholdHandling.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestAttributeThresholdHandling.expected
@@ -9,7 +9,7 @@
       <Setter Property="Text" Value="Default Text &amp;&lt;" />
       <Style.Triggers>
         <!--  Elements no line break between attributes: "Trigger"  -->
-        <Trigger Property="IsEnabled" Value="false">
+        <Trigger Property="IsEnabled" Value="false" >
           <Setter Property="Background" Value="#EEEEEE" />
         </Trigger>
 

--- a/XamlStyler.UnitTests/TestFiles/TestAttributeToleranceHandling.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestAttributeToleranceHandling.expected
@@ -1,12 +1,12 @@
 ﻿<Window x:Class="MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" >
   <Window.Resources>
-    <Style TargetType="TextBox">
+    <Style TargetType="TextBox" >
       <Setter Property="Text" Value="Default Text &amp;&lt;" />
       <Style.Triggers>
         <!--  Elements no line break between attributes: "Trigger"  -->
-        <Trigger Property="IsEnabled" Value="false">
+        <Trigger Property="IsEnabled" Value="false" >
           <Setter Property="Background" Value="#EEEEEE" />
         </Trigger>
 
@@ -38,7 +38,7 @@
                Height="Auto"
                Margin="0,0,0,0"
                HorizontalAlignment="Stretch"
-               VerticalAlignment="Stretch">
+               VerticalAlignment="Stretch" >
       <StackPanel>
         <StackPanel.Background>
           <LinearGradientBrush>
@@ -48,7 +48,7 @@
             <GradientStop Offset="1" Color="White" />
           </LinearGradientBrush>
         </StackPanel.Background>
-        <StackPanel Margin="10">
+        <StackPanel Margin="10" >
           <TextBlock Text="Camera X Position:" />
           <TextBox Name="cameraPositionXTextBox" HorizontalAlignment="Left" />
           <TextBlock Text="Camera Y Position:" />
@@ -67,11 +67,11 @@
                    Text="-9" />
           <Separator />
 
-          <Button Name="simpleButton" Click="simpleButtonClick">Simple</Button>
-          <Button Name="cubeButton" Click="cubeButtonClick">Cube</Button>
+          <Button Name="simpleButton" Click="simpleButtonClick" >Simple</Button>
+          <Button Name="cubeButton" Click="cubeButtonClick" >Cube</Button>
         </StackPanel>
       </StackPanel>
-      <Viewport3D Name="mainViewport" ClipToBounds="True">
+      <Viewport3D Name="mainViewport" ClipToBounds="True" >
         <Viewport3D.Camera>
           <PerspectiveCamera FarPlaneDistance="100"
                              FieldOfView="70"

--- a/XamlStyler.UnitTests/TestFiles/TestBindingSplitting.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestBindingSplitting.expected
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="MainWindow"
         Width="525"
-        Height="350">
+        Height="350" >
   <Grid>
     <TextBlock FontFamily="Arial"
                FontSize="18"

--- a/XamlStyler.UnitTests/TestFiles/TestCDATAHandling.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestCDATAHandling.expected
@@ -5,7 +5,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              d:DesignHeight="300"
              d:DesignWidth="300"
-             mc:Ignorable="d">
+             mc:Ignorable="d" >
   <x:Code>
     <![CDATA[ public Method1() {}]]>
   </x:Code>

--- a/XamlStyler.UnitTests/TestFiles/TestCanvasChildrenHandling.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestCanvasChildrenHandling.expected
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="WPF3D"
         Width="534"
-        Height="254">
+        Height="254" >
 
   <Grid>
 

--- a/XamlStyler.UnitTests/TestFiles/TestClosingElementHandling_1.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestClosingElementHandling_1.expected
@@ -10,10 +10,10 @@
   <SingleAmp>&amp;</SingleAmp>
   <SingleLine>test here</SingleLine>
   <SingleLine>test here</SingleLine>
-  <SingleLine a="a" b="b">test here</SingleLine>
+  <SingleLine a="a" b="b" >test here</SingleLine>
   <SingleLineWithLinefeed a="a"
                           b="b"
-                          c="c">
+                          c="c" >
     line
   </SingleLineWithLinefeed>
   <SingleLineWithComment>

--- a/XamlStyler.UnitTests/TestFiles/TestDefaultHandling.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestDefaultHandling.expected
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="WPF3D"
         Width="534"
-        Height="254">
+        Height="254" >
   <Grid>
     <!--  Attribute Value With XML Character Entities, e.g., &#10;  -->
     <TextBlock Text="Some&#10;&amp;&gt;&lt;&quot;' Text" />
@@ -22,7 +22,7 @@
                Height="Auto"
                Margin="0,0,0,0"
                HorizontalAlignment="Stretch"
-               VerticalAlignment="Stretch">
+               VerticalAlignment="Stretch" >
       <StackPanel>
         <StackPanel.Background>
           <LinearGradientBrush>
@@ -32,7 +32,7 @@
             <GradientStop Offset="1" Color="White" />
           </LinearGradientBrush>
         </StackPanel.Background>
-        <StackPanel Margin="10">
+        <StackPanel Margin="10" >
           <TextBlock Text="Camera X Position:" />
           <TextBox Name="cameraPositionXTextBox"
                    HorizontalAlignment="Left"
@@ -66,12 +66,12 @@
                    Text="-10" />
           <Separator />
 
-          <Button Name="simpleButton" Click="simpleButtonClick">Simple</Button>
-          <Button Name="cubeButton" Click="cubeButtonClick">Cube</Button>
+          <Button Name="simpleButton" Click="simpleButtonClick" >Simple</Button>
+          <Button Name="cubeButton" Click="cubeButtonClick" >Cube</Button>
         </StackPanel>
       </StackPanel>
       <!--#region This is a ViewPort-->
-      <Viewport3D Name="mainViewport" ClipToBounds="True">
+      <Viewport3D Name="mainViewport" ClipToBounds="True" >
         <Viewport3D.Camera>
           <PerspectiveCamera FarPlaneDistance="100"
                              FieldOfView="70"

--- a/XamlStyler.UnitTests/TestFiles/TestDesignReferenceRemoval.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestDesignReferenceRemoval.expected
@@ -1,7 +1,7 @@
 ﻿<UserControl x:Class="App1.MyUserControl1"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="using:App1">
+             xmlns:local="using:App1" >
 
   <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
 </UserControl>

--- a/XamlStyler.UnitTests/TestFiles/TestGridChildrenHandling.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestGridChildrenHandling.expected
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Width="534"
-        Height="254">
+        Height="254" >
   <Grid>
     <Grid.RowDefinitions>
       <RowDefinition />

--- a/XamlStyler.UnitTests/TestFiles/TestKeepSelectAttributesOnFirstLine.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestKeepSelectAttributesOnFirstLine.expected
@@ -1,6 +1,6 @@
 ﻿<Window x:Class="MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" >
   <Grid>
     <Button x:Name="Test" Content="Button 1" />
     <Button x:Name="Test2"

--- a/XamlStyler.UnitTests/TestFiles/TestMarkupExtensionHandling_2_spaces.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestMarkupExtensionHandling_2_spaces.expected
@@ -1,7 +1,7 @@
 ﻿<Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:sys="clr-namespace:System;assembly=mscorlib"
-      Title="Page Title">
+      Title="Page Title" >
   <Grid>
     <!--  Tolerant element, no break line in markup extension  -->
     <TextBlock Text="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Page}}, Path=Title, StringFormat={}{0}Now{{0}} - {0}}" />

--- a/XamlStyler.UnitTests/TestFiles/TestMarkupExtensionHandling_2_tabs.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestMarkupExtensionHandling_2_tabs.expected
@@ -1,7 +1,7 @@
 ﻿<Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 			xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 			xmlns:sys="clr-namespace:System;assembly=mscorlib"
-			Title="Page Title">
+			Title="Page Title" >
 	<Grid>
 		<!--  Tolerant element, no break line in markup extension  -->
 		<TextBlock Text="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Page}}, Path=Title, StringFormat={}{0}Now{{0}} - {0}}" />

--- a/XamlStyler.UnitTests/TestFiles/TestMarkupExtensionHandling_4_spaces.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestMarkupExtensionHandling_4_spaces.expected
@@ -1,7 +1,7 @@
 ﻿<Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:sys="clr-namespace:System;assembly=mscorlib"
-      Title="Page Title">
+      Title="Page Title" >
     <Grid>
         <!--  Tolerant element, no break line in markup extension  -->
         <TextBlock Text="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Page}}, Path=Title, StringFormat={}{0}Now{{0}} - {0}}" />

--- a/XamlStyler.UnitTests/TestFiles/TestMarkupExtensionHandling_4_tabs.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestMarkupExtensionHandling_4_tabs.expected
@@ -1,7 +1,7 @@
 ﻿<Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	  xmlns:sys="clr-namespace:System;assembly=mscorlib"
-	  Title="Page Title">
+	  Title="Page Title" >
 	<Grid>
 		<!--  Tolerant element, no break line in markup extension  -->
 		<TextBlock Text="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Page}}, Path=Title, StringFormat={}{0}Now{{0}} - {0}}" />

--- a/XamlStyler.UnitTests/TestFiles/TestMarkupWithAttributeNotOnFirstLine.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestMarkupWithAttributeNotOnFirstLine.expected
@@ -3,7 +3,7 @@
     a="a"
     b="{Binding Test,
                 Converter={StaticResource VisibilityConverter},
-                ConverterParameter=Inverse}">
+                ConverterParameter=Inverse}" >
     test here
   </SingleLineContent>
   <SingleLineNoContent
@@ -15,7 +15,7 @@
     a="a"
     b="{Binding Test,
                 Converter={StaticResource VisibilityConverter},
-                ConverterParameter=Inverse}">
+                ConverterParameter=Inverse}" >
     test here
   </MultiLineContent>
   <MultiLineNoContent
@@ -27,7 +27,7 @@
     a="a"
     b="{Binding Test,
                 Converter={StaticResource VisibilityConverter},
-                ConverterParameter=Inverse}">
+                ConverterParameter=Inverse}" >
     test here
   </MultiLineProperContent>
   <MultiLineProperNoContent

--- a/XamlStyler.UnitTests/TestFiles/TestNestedCanvasChildrenHandling.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestNestedCanvasChildrenHandling.expected
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="WPF3D"
         Width="534"
-        Height="254">
+        Height="254" >
   <Grid>
 
 
@@ -28,7 +28,7 @@
                  Canvas.Bottom="30"
                  Text="Four" />
 
-      <Canvas Canvas.Left="120">
+      <Canvas Canvas.Left="120" >
 
         <TextBlock Canvas.Left="30"
                    Canvas.Top="0"

--- a/XamlStyler.UnitTests/TestFiles/TestNestedCustomMarkupExtensionsWithBindings.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestNestedCustomMarkupExtensionsWithBindings.expected
@@ -3,7 +3,7 @@
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
   xmlns:local="clr-namespace:WpfApplication"
-  Title="MainWindow">
+  Title="MainWindow" >
   <Grid>
     <Button
       Content="Click Me"

--- a/XamlStyler.UnitTests/TestFiles/TestNestedGridChildrenHandling.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestNestedGridChildrenHandling.expected
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="WPF3D"
         Width="534"
-        Height="254">
+        Height="254" >
   <Grid>
     <Grid.RowDefinitions>
       <RowDefinition />
@@ -22,7 +22,7 @@
 
     <TextBlock Grid.Row="1" Text="one, zero" />
 
-    <Grid Grid.Row="1" Grid.Column="0">
+    <Grid Grid.Row="1" Grid.Column="0" >
       <Grid.RowDefinitions>
         <RowDefinition />
         <RowDefinition />

--- a/XamlStyler.UnitTests/TestFiles/TestNestedPropertiesAndChildrenHandling.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestNestedPropertiesAndChildrenHandling.expected
@@ -8,7 +8,7 @@
       x:Name="pageRoot"
       DataContext="{Binding DefaultViewModel,
                             RelativeSource={RelativeSource Self}}"
-      mc:Ignorable="d">
+      mc:Ignorable="d" >
 
   <Page.Resources>
     <!--  Collection of items displayed by this page  -->
@@ -20,7 +20,7 @@
     * Row 0 contains the back button and page title
     * Row 1 contains the rest of the page layout
   -->
-  <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+  <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" >
     <Grid.ChildrenTransitions>
       <TransitionCollection>
         <EntranceThemeTransition />
@@ -39,20 +39,20 @@
     <VisualStateManager.VisualStateGroups>
 
       <!--  Visual states reflect the application's view state  -->
-      <VisualStateGroup x:Name="ViewStates">
+      <VisualStateGroup x:Name="ViewStates" >
         <VisualState x:Name="PrimaryView" />
-        <VisualState x:Name="SinglePane">
+        <VisualState x:Name="SinglePane" >
           <Storyboard>
-            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="primaryColumn" Storyboard.TargetProperty="Width">
+            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="primaryColumn" Storyboard.TargetProperty="Width" >
               <DiscreteObjectKeyFrame KeyTime="0" Value="*" />
             </ObjectAnimationUsingKeyFrames>
-            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="secondaryColumn" Storyboard.TargetProperty="Width">
+            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="secondaryColumn" Storyboard.TargetProperty="Width" >
               <DiscreteObjectKeyFrame KeyTime="0" Value="0" />
             </ObjectAnimationUsingKeyFrames>
-            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="itemDetail" Storyboard.TargetProperty="Visibility">
+            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="itemDetail" Storyboard.TargetProperty="Visibility" >
               <DiscreteObjectKeyFrame KeyTime="0" Value="Collapsed" />
             </ObjectAnimationUsingKeyFrames>
-            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="itemListView" Storyboard.TargetProperty="Padding">
+            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="itemListView" Storyboard.TargetProperty="Padding" >
               <DiscreteObjectKeyFrame KeyTime="0" Value="120,0,90,60" />
             </ObjectAnimationUsingKeyFrames>
           </Storyboard>
@@ -64,27 +64,27 @@
           * Move the title directly above the details
           * Adjust padding for details
         -->
-        <VisualState x:Name="SinglePane_Detail">
+        <VisualState x:Name="SinglePane_Detail" >
           <Storyboard>
-            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="primaryColumn" Storyboard.TargetProperty="Width">
+            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="primaryColumn" Storyboard.TargetProperty="Width" >
               <DiscreteObjectKeyFrame KeyTime="0" Value="0" />
             </ObjectAnimationUsingKeyFrames>
-            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="itemListView" Storyboard.TargetProperty="Visibility">
+            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="itemListView" Storyboard.TargetProperty="Visibility" >
               <DiscreteObjectKeyFrame KeyTime="0" Value="Collapsed" />
             </ObjectAnimationUsingKeyFrames>
-            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="itemDetail" Storyboard.TargetProperty="(Grid.Row)">
+            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="itemDetail" Storyboard.TargetProperty="(Grid.Row)" >
               <DiscreteObjectKeyFrame KeyTime="0" Value="1" />
             </ObjectAnimationUsingKeyFrames>
-            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="itemDetail" Storyboard.TargetProperty="(Grid.RowSpan)">
+            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="itemDetail" Storyboard.TargetProperty="(Grid.RowSpan)" >
               <DiscreteObjectKeyFrame KeyTime="0" Value="1" />
             </ObjectAnimationUsingKeyFrames>
-            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="titlePanel" Storyboard.TargetProperty="(Grid.Column)">
+            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="titlePanel" Storyboard.TargetProperty="(Grid.Column)" >
               <DiscreteObjectKeyFrame KeyTime="0" Value="1" />
             </ObjectAnimationUsingKeyFrames>
-            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="itemDetailGrid" Storyboard.TargetProperty="Margin">
+            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="itemDetailGrid" Storyboard.TargetProperty="Margin" >
               <DiscreteObjectKeyFrame KeyTime="0" Value="0,0,0,60" />
             </ObjectAnimationUsingKeyFrames>
-            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="itemDetail" Storyboard.TargetProperty="Padding">
+            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="itemDetail" Storyboard.TargetProperty="Padding" >
               <DiscreteObjectKeyFrame KeyTime="0" Value="120,0,90,0" />
             </ObjectAnimationUsingKeyFrames>
           </Storyboard>
@@ -93,7 +93,7 @@
     </VisualStateManager.VisualStateGroups>
 
     <!--  Back button and page title  -->
-    <Grid x:Name="titlePanel">
+    <Grid x:Name="titlePanel" >
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="120" />
         <ColumnDefinition Width="*" />
@@ -127,9 +127,9 @@
                   ScrollViewer.HorizontalScrollMode="Disabled"
                   ScrollViewer.VerticalScrollMode="Enabled"
                   ScrollViewer.ZoomMode="Disabled"
-                  VerticalScrollBarVisibility="Auto">
+                  VerticalScrollBarVisibility="Auto" >
 
-      <Grid x:Name="itemDetailGrid" Margin="0,60,0,50">
+      <Grid x:Name="itemDetailGrid" Margin="0,60,0,50" >
         <Grid.RowDefinitions>
           <RowDefinition Height="Auto" />
           <RowDefinition Height="Auto" />
@@ -149,7 +149,7 @@
                Stretch="UniformToFill" />
         <StackPanel x:Name="itemDetailTitlePanel"
                     Grid.Row="1"
-                    Grid.Column="1">
+                    Grid.Column="1" >
           <TextBlock x:Name="itemTitle"
                      Margin="0,-10,0,0"
                      Style="{StaticResource SubheaderTextBlockStyle}"
@@ -176,22 +176,22 @@
               ItemsSource="{Binding Source={StaticResource itemsViewSource}}"
               Padding="120,0,0,60"
               SelectionChanged="ItemListView_SelectionChanged"
-              TabIndex="1">
+              TabIndex="1" >
       <ListView.ItemTemplate>
         <DataTemplate>
-          <Grid Margin="6">
+          <Grid Margin="6" >
             <Grid.ColumnDefinitions>
               <ColumnDefinition Width="Auto" />
               <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
             <Border Width="60"
                     Height="60"
-                    Background="{ThemeResource ListViewItemPlaceholderBackgroundThemeBrush}">
+                    Background="{ThemeResource ListViewItemPlaceholderBackgroundThemeBrush}" >
               <Image AutomationProperties.Name="{Binding Title}"
                      Source="{Binding ImagePath}"
                      Stretch="UniformToFill" />
             </Border>
-            <StackPanel Grid.Column="1" Margin="10,0,0,0">
+            <StackPanel Grid.Column="1" Margin="10,0,0,0" >
               <TextBlock MaxHeight="40"
                          Style="{StaticResource TitleTextBlockStyle}"
                          Text="{Binding Title}"
@@ -204,7 +204,7 @@
         </DataTemplate>
       </ListView.ItemTemplate>
       <ListView.ItemContainerStyle>
-        <Style TargetType="FrameworkElement">
+        <Style TargetType="FrameworkElement" >
           <Setter Property="Margin" Value="0,0,0,10" />
         </Style>
       </ListView.ItemContainerStyle>

--- a/XamlStyler.UnitTests/TestFiles/TestReorderSetterHandling_Property.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestReorderSetterHandling_Property.expected
@@ -12,28 +12,28 @@
              d:DataContext="{d:DesignInstance documentViewModels:DocumentViewModel}"
              d:DesignHeight="70"
              d:DesignWidth="1024"
-             mc:Ignorable="d">
+             mc:Ignorable="d" >
   <UserControl.Resources>
     <SolidColorBrush x:Key="DocumentForegroundBrush" Color="#333" />
     <SolidColorBrush x:Key="DocumentHoverBrush" Color="#F5F5F5" />
     <SolidColorBrush x:Key="DocumentBorderBrush" Color="#DDD" />
 
     <Style x:Key="EmptySetterStyle" TargetType="Border" />
-    <Style x:Key="SingleSetterStyle" TargetType="Border">
+    <Style x:Key="SingleSetterStyle" TargetType="Border" >
       <!--  Test: Verify that comments are kept  -->
       <Setter Property="BorderBrush" Value="{StaticResource DocumentBorderBrush}" />
       <!--  Test: Verify that comments are kept at bottom  -->
     </Style>
-    <Style x:Key="DocumentTableStyle" TargetType="Border">
+    <Style x:Key="DocumentTableStyle" TargetType="Border" >
       <Setter Property="BorderBrush" Value="{StaticResource DocumentBorderBrush}" />
       <Setter Property="BorderThickness" Value="0.5" />
     </Style>
     <!--  Test: Verify that custom nodes are not reordered despite containing setters  -->
-    <SomeCustomElement x:Key="DocumentTableStyle" TargetType="Border">
+    <SomeCustomElement x:Key="DocumentTableStyle" TargetType="Border" >
       <Setter Property="BorderThickness" Value="0.5" />
       <Setter Property="BorderBrush" Value="{StaticResource DocumentBorderBrush}" />
     </SomeCustomElement>
-    <Style x:Key="DocumentTableTextStyle" TargetType="FrameworkElement">
+    <Style x:Key="DocumentTableTextStyle" TargetType="FrameworkElement" >
       <Setter Property="HorizontalAlignment" Value="Center" />
       <!--  Test: Verify that comments are moved with Margin element  -->
       <Setter Property="Margin" Value="8" />
@@ -42,15 +42,15 @@
       <Setter Property="VerticalAlignment" Value="Center" />
       <!--  Test: Verify that comments are not moved from last position  -->
     </Style>
-    <Style x:Key="GridHooverStyle" TargetType="Grid">
+    <Style x:Key="GridHooverStyle" TargetType="Grid" >
       <Style.Triggers>
-        <Trigger Property="IsMouseOver" Value="True">
+        <Trigger Property="IsMouseOver" Value="True" >
           <Setter Property="Background" Value="{StaticResource DocumentHoverBrush}" />
           <Setter Property="Foreground" Value="{StaticResource DocumentForegroundHoverBrush}" />
         </Trigger>
       </Style.Triggers>
     </Style>
-    <Style x:Key="QuestionDisplayTextStyle" TargetType="TextBlock">
+    <Style x:Key="QuestionDisplayTextStyle" TargetType="TextBlock" >
       <Setter Property="FontFamily" Value="Helvetica Neue,Helvetica,Arial,sans-serif" />
       <Setter Property="FontSize" Value="14" />
       <Setter Property="Foreground" Value="{StaticResource QuestionnaireColorBrush}" />
@@ -60,7 +60,7 @@
       <Setter Property="VerticalAlignment" Value="Center" />
       <!--  Different styling when used from QuickSizing  -->
       <Style.Triggers>
-        <DataTrigger Binding="{Binding QuestionOwnerType}" Value="{x:Type sizingViewModels:QuickSizingViewModel}">
+        <DataTrigger Binding="{Binding QuestionOwnerType}" Value="{x:Type sizingViewModels:QuickSizingViewModel}" >
           <Setter Property="FontStyle" Value="Italic" />
           <Setter Property="HorizontalAlignment" Value="Right" />
           <Setter Property="MaxWidth" Value="100" />
@@ -69,7 +69,7 @@
         <MultiDataTrigger>
           <MultiDataTrigger.Conditions>
             <Condition Binding="{Binding QuestionOwnerType}" Value="{x:Type sizingViewModels:QuickSizingViewModel}" />
-            <Condition Binding="{Binding SettingsViewModel.WindowSize, Source={StaticResource ViewModelLocator}}">
+            <Condition Binding="{Binding SettingsViewModel.WindowSize, Source={StaticResource ViewModelLocator}}" >
               <Condition.Value>
                 <enums:WindowSize>MediumSmall</enums:WindowSize>
               </Condition.Value>
@@ -79,7 +79,7 @@
           <Setter Property="MaxWidth" Value="{x:Static sys:Double.PositiveInfinity}" />
           <Setter Property="TextAlignment" Value="Left" />
         </MultiDataTrigger>
-        <DataTrigger Binding="{Binding SettingsViewModel.WindowSize, Source={StaticResource ViewModelLocator}}">
+        <DataTrigger Binding="{Binding SettingsViewModel.WindowSize, Source={StaticResource ViewModelLocator}}" >
           <DataTrigger.Value>
             <enums:WindowSize>Small</enums:WindowSize>
           </DataTrigger.Value>
@@ -89,19 +89,19 @@
         </DataTrigger>
       </Style.Triggers>
     </Style>
-    <Style TargetType="{x:Type TabControl}">
+    <Style TargetType="{x:Type TabControl}" >
       <Setter Property="Background" Value="{StaticResource TabBackgroundBrush}" />
       <Setter Property="BorderBrush" Value="{StaticResource LightBorderBrush}" />
       <Setter Property="BorderThickness" Value="1" />
       <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
       <Setter Property="HorizontalContentAlignment" Value="Center" />
       <Setter Property="Padding" Value="4,4,4,4" />
-      <Setter Property="Template">
+      <Setter Property="Template" >
         <Setter.Value>
-          <ControlTemplate TargetType="{x:Type TabControl}">
+          <ControlTemplate TargetType="{x:Type TabControl}" >
             <Grid ClipToBounds="true"
                   KeyboardNavigation.TabNavigation="Local"
-                  SnapsToDevicePixels="true">
+                  SnapsToDevicePixels="true" >
               <Grid.ColumnDefinitions>
                 <ColumnDefinition x:Name="ColumnDefinition0" />
                 <ColumnDefinition x:Name="ColumnDefinition1" Width="0" />
@@ -126,7 +126,7 @@
                       BorderThickness="{TemplateBinding BorderThickness}"
                       KeyboardNavigation.DirectionalNavigation="Contained"
                       KeyboardNavigation.TabIndex="2"
-                      KeyboardNavigation.TabNavigation="Local">
+                      KeyboardNavigation.TabNavigation="Local" >
                 <ContentPresenter x:Name="PART_SelectedContentHost"
                                   Margin="{TemplateBinding Padding}"
                                   ContentSource="SelectedContent"
@@ -134,17 +134,17 @@
               </Border>
             </Grid>
             <ControlTemplate.Triggers>
-              <Trigger Property="TabStripPlacement" Value="Top">
+              <Trigger Property="TabStripPlacement" Value="Top" >
                 <!--<Setter Property="Height" TargetName="HeaderPanel" Value="38" />-->
               </Trigger>
-              <Trigger Property="TabStripPlacement" Value="Bottom">
+              <Trigger Property="TabStripPlacement" Value="Bottom" >
                 <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="1" />
                 <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
                 <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
                 <Setter TargetName="RowDefinition1" Property="Height" Value="Auto" />
                 <Setter TargetName="HeaderPanel" Property="Margin" Value="0,-1,0,0" />
               </Trigger>
-              <Trigger Property="TabStripPlacement" Value="Left">
+              <Trigger Property="TabStripPlacement" Value="Left" >
                 <Setter TargetName="HeaderPanel" Property="Grid.Column" Value="0" />
                 <Setter TargetName="ContentPanel" Property="Grid.Column" Value="1" />
                 <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="0" />
@@ -156,7 +156,7 @@
                 <Setter TargetName="ColumnDefinition1" Property="Width" Value="*" />
                 <Setter TargetName="HeaderPanel" Property="Width" Value="103" />
               </Trigger>
-              <Trigger Property="TabStripPlacement" Value="Right">
+              <Trigger Property="TabStripPlacement" Value="Right" >
                 <Setter TargetName="HeaderPanel" Property="Grid.Column" Value="1" />
                 <Setter TargetName="ContentPanel" Property="Grid.Column" Value="0" />
                 <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="0" />
@@ -167,7 +167,7 @@
                 <Setter TargetName="ColumnDefinition0" Property="Width" Value="*" />
                 <Setter TargetName="ColumnDefinition1" Property="Width" Value="Auto" />
               </Trigger>
-              <Trigger Property="IsEnabled" Value="false">
+              <Trigger Property="IsEnabled" Value="false" >
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
               </Trigger>
             </ControlTemplate.Triggers>
@@ -176,18 +176,18 @@
       </Setter>
       <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
-    <Style TargetType="{x:Type TabItem}">
-      <Setter Property="Template">
+    <Style TargetType="{x:Type TabItem}" >
+      <Setter Property="Template" >
         <Setter.Value>
-          <ControlTemplate TargetType="{x:Type TabItem}">
+          <ControlTemplate TargetType="{x:Type TabItem}" >
             <Grid HorizontalAlignment="Stretch"
                   VerticalAlignment="Stretch"
-                  SnapsToDevicePixels="true">
+                  SnapsToDevicePixels="true" >
               <Border Name="Border"
                       Background="{StaticResource TabEnabledBackgroundBrush}"
                       BorderBrush="{StaticResource LightBorderBrush}"
                       BorderThickness="1"
-                      CornerRadius="0">
+                      CornerRadius="0" >
                 <ContentPresenter x:Name="ContentSite"
                                   Margin="15,10,15,10"
                                   HorizontalAlignment="Center"
@@ -197,20 +197,20 @@
               </Border>
             </Grid>
             <ControlTemplate.Triggers>
-              <Trigger Property="TabStripPlacement" Value="Top">
+              <Trigger Property="TabStripPlacement" Value="Top" >
                 <!--<Setter TargetName="ContentSite" Property="Height" Value="38" />-->
                 <Setter TargetName="Border" Property="Margin" Value="0,0,0,-1" />
               </Trigger>
-              <Trigger Property="TabStripPlacement" Value="Left">
+              <Trigger Property="TabStripPlacement" Value="Left" >
                 <Setter TargetName="ContentSite" Property="Height" Value="95" />
                 <Setter TargetName="ContentSite" Property="Margin" Value="0" />
                 <Setter TargetName="Border" Property="Margin" Value="0,0,-1,0" />
               </Trigger>
-              <Trigger Property="IsMouseOver" Value="True">
+              <Trigger Property="IsMouseOver" Value="True" >
                 <Setter TargetName="Border" Property="Background" Value="{StaticResource TabMouseOverBackgroundBrush}" />
                 <Setter Property="TextBlock.Foreground" Value="{StaticResource TabMouseOverForegroundBrush}" />
               </Trigger>
-              <Trigger Property="IsSelected" Value="True">
+              <Trigger Property="IsSelected" Value="True" >
                 <Setter TargetName="Border" Property="Background" Value="{StaticResource TabBackgroundBrush}" />
                 <Setter TargetName="Border" Property="Cursor" Value="Pen" />
                 <Setter Property="Panel.ZIndex" Value="1" />
@@ -233,10 +233,10 @@
                 </MultiTrigger.Conditions>
                 <Setter TargetName="Border" Property="BorderThickness" Value="1,1,0,1" />
               </MultiTrigger>
-              <Trigger Property="IsEnabled" Value="True">
+              <Trigger Property="IsEnabled" Value="True" >
                 <Setter TargetName="Border" Property="Cursor" Value="Hand" />
               </Trigger>
-              <Trigger Property="IsEnabled" Value="False">
+              <Trigger Property="IsEnabled" Value="False" >
                 <Setter TargetName="Border" Property="Background" Value="{StaticResource TabDisabledBackgroundBrush}" />
                 <Setter Property="TextBlock.Foreground" Value="{StaticResource TabDisabledForegroundBrush}" />
               </Trigger>
@@ -246,7 +246,7 @@
       </Setter>
     </Style>
   </UserControl.Resources>
-  <Grid Style="{StaticResource GridHooverStyle}" ToolTip="{Binding Description}">
+  <Grid Style="{StaticResource GridHooverStyle}" ToolTip="{Binding Description}" >
     <i:Interaction.Behaviors>
       <behaviors:CommandBehavior Command="{Binding ToggleCheckBoxCommand}" />
       <behaviors:CommandBehavior Command="{Binding DataContext.RecalculateAllIsCheckedCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type documentViews:DocumentsView}}}" />
@@ -261,32 +261,32 @@
       <ColumnDefinition Width="Auto" SharedSizeGroup="LitDate" />
     </Grid.ColumnDefinitions>
 
-    <Border Grid.Column="0" Style="{StaticResource DocumentTableStyle}">
+    <Border Grid.Column="0" Style="{StaticResource DocumentTableStyle}" >
       <CheckBox Margin="10,0,0,0"
                 Command="{Binding DataContext.RecalculateAllIsCheckedCommand,
                                   RelativeSource={RelativeSource FindAncestor,
                                                                  AncestorType={x:Type documentViews:DocumentsView}}}"
                 IsChecked="{Binding IsChecked}" />
     </Border>
-    <Border Grid.Column="1" Style="{StaticResource DocumentTableStyle}">
+    <Border Grid.Column="1" Style="{StaticResource DocumentTableStyle}" >
       <TextBlock Margin="8"
                  HorizontalAlignment="Left"
-                 VerticalAlignment="Center">
-        <Hyperlink Command="{Binding DocumentClickCommand}" Style="{StaticResource HyperlinkStyle}">
+                 VerticalAlignment="Center" >
+        <Hyperlink Command="{Binding DocumentClickCommand}" Style="{StaticResource HyperlinkStyle}" >
           <TextBlock Text="{Binding Title}" />
         </Hyperlink>
       </TextBlock>
     </Border>
-    <Border Grid.Column="2" Style="{StaticResource DocumentTableStyle}">
+    <Border Grid.Column="2" Style="{StaticResource DocumentTableStyle}" >
       <TextBlock Style="{StaticResource DocumentTableTextStyle}" Text="{Binding PrefixedLanguageCode}" />
     </Border>
-    <Border Grid.Column="3" Style="{StaticResource DocumentTableStyle}">
+    <Border Grid.Column="3" Style="{StaticResource DocumentTableStyle}" >
       <TextBlock Style="{StaticResource DocumentTableTextStyle}" Text="{Binding TypeCode}" />
     </Border>
-    <Border Grid.Column="4" Style="{StaticResource DocumentTableStyle}">
+    <Border Grid.Column="4" Style="{StaticResource DocumentTableStyle}" >
       <TextBlock Style="{StaticResource DocumentTableTextStyle}" Text="{Binding DataContext.ProductType, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type documentViews:DocumentsView}}}" />
     </Border>
-    <Border Grid.Column="5" Style="{StaticResource DocumentTableStyle}">
+    <Border Grid.Column="5" Style="{StaticResource DocumentTableStyle}" >
       <TextBlock Style="{StaticResource DocumentTableTextStyle}" Text="{Binding PublishedDate}" />
     </Border>
   </Grid>

--- a/XamlStyler.UnitTests/TestFiles/TestReorderSetterHandling_TargetName.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestReorderSetterHandling_TargetName.expected
@@ -12,28 +12,28 @@
              d:DataContext="{d:DesignInstance documentViewModels:DocumentViewModel}"
              d:DesignHeight="70"
              d:DesignWidth="1024"
-             mc:Ignorable="d">
+             mc:Ignorable="d" >
   <UserControl.Resources>
     <SolidColorBrush x:Key="DocumentForegroundBrush" Color="#333" />
     <SolidColorBrush x:Key="DocumentHoverBrush" Color="#F5F5F5" />
     <SolidColorBrush x:Key="DocumentBorderBrush" Color="#DDD" />
 
     <Style x:Key="EmptySetterStyle" TargetType="Border" />
-    <Style x:Key="SingleSetterStyle" TargetType="Border">
+    <Style x:Key="SingleSetterStyle" TargetType="Border" >
       <!--  Test: Verify that comments are kept  -->
       <Setter Property="BorderBrush" Value="{StaticResource DocumentBorderBrush}" />
       <!--  Test: Verify that comments are kept at bottom  -->
     </Style>
-    <Style x:Key="DocumentTableStyle" TargetType="Border">
+    <Style x:Key="DocumentTableStyle" TargetType="Border" >
       <Setter Property="BorderThickness" Value="0.5" />
       <Setter Property="BorderBrush" Value="{StaticResource DocumentBorderBrush}" />
     </Style>
     <!--  Test: Verify that custom nodes are not reordered despite containing setters  -->
-    <SomeCustomElement x:Key="DocumentTableStyle" TargetType="Border">
+    <SomeCustomElement x:Key="DocumentTableStyle" TargetType="Border" >
       <Setter Property="BorderThickness" Value="0.5" />
       <Setter Property="BorderBrush" Value="{StaticResource DocumentBorderBrush}" />
     </SomeCustomElement>
-    <Style x:Key="DocumentTableTextStyle" TargetType="FrameworkElement">
+    <Style x:Key="DocumentTableTextStyle" TargetType="FrameworkElement" >
       <!--  Test: Verify that comments are moved with VerticalAlignment element  -->
       <Setter Property="VerticalAlignment" Value="Center" />
       <Setter Property="TextBlock.Foreground" Value="{StaticResource DocumentForegroundBrush}" />
@@ -42,15 +42,15 @@
       <Setter Property="Margin" Value="8" />
       <!--  Test: Verify that comments are not moved from last position  -->
     </Style>
-    <Style x:Key="GridHooverStyle" TargetType="Grid">
+    <Style x:Key="GridHooverStyle" TargetType="Grid" >
       <Style.Triggers>
-        <Trigger Property="IsMouseOver" Value="True">
+        <Trigger Property="IsMouseOver" Value="True" >
           <Setter Property="Background" Value="{StaticResource DocumentHoverBrush}" />
           <Setter Property="Foreground" Value="{StaticResource DocumentForegroundHoverBrush}" />
         </Trigger>
       </Style.Triggers>
     </Style>
-    <Style x:Key="QuestionDisplayTextStyle" TargetType="TextBlock">
+    <Style x:Key="QuestionDisplayTextStyle" TargetType="TextBlock" >
       <Setter Property="FontFamily" Value="Helvetica Neue,Helvetica,Arial,sans-serif" />
       <Setter Property="FontSize" Value="14" />
       <Setter Property="Foreground" Value="{StaticResource QuestionnaireColorBrush}" />
@@ -60,7 +60,7 @@
       <Setter Property="VerticalAlignment" Value="Center" />
       <!--  Different styling when used from QuickSizing  -->
       <Style.Triggers>
-        <DataTrigger Binding="{Binding QuestionOwnerType}" Value="{x:Type sizingViewModels:QuickSizingViewModel}">
+        <DataTrigger Binding="{Binding QuestionOwnerType}" Value="{x:Type sizingViewModels:QuickSizingViewModel}" >
           <Setter Property="HorizontalAlignment" Value="Right" />
           <Setter Property="FontStyle" Value="Italic" />
           <Setter Property="TextAlignment" Value="Right" />
@@ -69,7 +69,7 @@
         <MultiDataTrigger>
           <MultiDataTrigger.Conditions>
             <Condition Binding="{Binding QuestionOwnerType}" Value="{x:Type sizingViewModels:QuickSizingViewModel}" />
-            <Condition Binding="{Binding SettingsViewModel.WindowSize, Source={StaticResource ViewModelLocator}}">
+            <Condition Binding="{Binding SettingsViewModel.WindowSize, Source={StaticResource ViewModelLocator}}" >
               <Condition.Value>
                 <enums:WindowSize>MediumSmall</enums:WindowSize>
               </Condition.Value>
@@ -79,7 +79,7 @@
           <Setter Property="TextAlignment" Value="Left" />
           <Setter Property="MaxWidth" Value="{x:Static sys:Double.PositiveInfinity}" />
         </MultiDataTrigger>
-        <DataTrigger Binding="{Binding SettingsViewModel.WindowSize, Source={StaticResource ViewModelLocator}}">
+        <DataTrigger Binding="{Binding SettingsViewModel.WindowSize, Source={StaticResource ViewModelLocator}}" >
           <DataTrigger.Value>
             <enums:WindowSize>Small</enums:WindowSize>
           </DataTrigger.Value>
@@ -89,7 +89,7 @@
         </DataTrigger>
       </Style.Triggers>
     </Style>
-    <Style TargetType="{x:Type TabControl}">
+    <Style TargetType="{x:Type TabControl}" >
       <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
       <Setter Property="Padding" Value="4,4,4,4" />
       <Setter Property="BorderThickness" Value="1" />
@@ -97,12 +97,12 @@
       <Setter Property="Background" Value="{StaticResource TabBackgroundBrush}" />
       <Setter Property="HorizontalContentAlignment" Value="Center" />
       <Setter Property="VerticalContentAlignment" Value="Center" />
-      <Setter Property="Template">
+      <Setter Property="Template" >
         <Setter.Value>
-          <ControlTemplate TargetType="{x:Type TabControl}">
+          <ControlTemplate TargetType="{x:Type TabControl}" >
             <Grid ClipToBounds="true"
                   KeyboardNavigation.TabNavigation="Local"
-                  SnapsToDevicePixels="true">
+                  SnapsToDevicePixels="true" >
               <Grid.ColumnDefinitions>
                 <ColumnDefinition x:Name="ColumnDefinition0" />
                 <ColumnDefinition x:Name="ColumnDefinition1" Width="0" />
@@ -127,7 +127,7 @@
                       BorderThickness="{TemplateBinding BorderThickness}"
                       KeyboardNavigation.DirectionalNavigation="Contained"
                       KeyboardNavigation.TabIndex="2"
-                      KeyboardNavigation.TabNavigation="Local">
+                      KeyboardNavigation.TabNavigation="Local" >
                 <ContentPresenter x:Name="PART_SelectedContentHost"
                                   Margin="{TemplateBinding Padding}"
                                   ContentSource="SelectedContent"
@@ -135,17 +135,17 @@
               </Border>
             </Grid>
             <ControlTemplate.Triggers>
-              <Trigger Property="TabStripPlacement" Value="Top">
+              <Trigger Property="TabStripPlacement" Value="Top" >
                 <!--<Setter Property="Height" TargetName="HeaderPanel" Value="38" />-->
               </Trigger>
-              <Trigger Property="TabStripPlacement" Value="Bottom">
+              <Trigger Property="TabStripPlacement" Value="Bottom" >
                 <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
                 <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="1" />
                 <Setter TargetName="HeaderPanel" Property="Margin" Value="0,-1,0,0" />
                 <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
                 <Setter TargetName="RowDefinition1" Property="Height" Value="Auto" />
               </Trigger>
-              <Trigger Property="TabStripPlacement" Value="Left">
+              <Trigger Property="TabStripPlacement" Value="Left" >
                 <Setter TargetName="ColumnDefinition0" Property="Width" Value="Auto" />
                 <Setter TargetName="ColumnDefinition1" Property="Width" Value="*" />
                 <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
@@ -157,7 +157,7 @@
                 <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
                 <Setter TargetName="RowDefinition1" Property="Height" Value="0" />
               </Trigger>
-              <Trigger Property="TabStripPlacement" Value="Right">
+              <Trigger Property="TabStripPlacement" Value="Right" >
                 <Setter TargetName="ColumnDefinition0" Property="Width" Value="*" />
                 <Setter TargetName="ColumnDefinition1" Property="Width" Value="Auto" />
                 <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
@@ -168,7 +168,7 @@
                 <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
                 <Setter TargetName="RowDefinition1" Property="Height" Value="0" />
               </Trigger>
-              <Trigger Property="IsEnabled" Value="false">
+              <Trigger Property="IsEnabled" Value="false" >
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
               </Trigger>
             </ControlTemplate.Triggers>
@@ -176,18 +176,18 @@
         </Setter.Value>
       </Setter>
     </Style>
-    <Style TargetType="{x:Type TabItem}">
-      <Setter Property="Template">
+    <Style TargetType="{x:Type TabItem}" >
+      <Setter Property="Template" >
         <Setter.Value>
-          <ControlTemplate TargetType="{x:Type TabItem}">
+          <ControlTemplate TargetType="{x:Type TabItem}" >
             <Grid HorizontalAlignment="Stretch"
                   VerticalAlignment="Stretch"
-                  SnapsToDevicePixels="true">
+                  SnapsToDevicePixels="true" >
               <Border Name="Border"
                       Background="{StaticResource TabEnabledBackgroundBrush}"
                       BorderBrush="{StaticResource LightBorderBrush}"
                       BorderThickness="1"
-                      CornerRadius="0">
+                      CornerRadius="0" >
                 <ContentPresenter x:Name="ContentSite"
                                   Margin="15,10,15,10"
                                   HorizontalAlignment="Center"
@@ -197,20 +197,20 @@
               </Border>
             </Grid>
             <ControlTemplate.Triggers>
-              <Trigger Property="TabStripPlacement" Value="Top">
+              <Trigger Property="TabStripPlacement" Value="Top" >
                 <!--<Setter TargetName="ContentSite" Property="Height" Value="38" />-->
                 <Setter TargetName="Border" Property="Margin" Value="0,0,0,-1" />
               </Trigger>
-              <Trigger Property="TabStripPlacement" Value="Left">
+              <Trigger Property="TabStripPlacement" Value="Left" >
                 <Setter TargetName="Border" Property="Margin" Value="0,0,-1,0" />
                 <Setter TargetName="ContentSite" Property="Height" Value="95" />
                 <Setter TargetName="ContentSite" Property="Margin" Value="0" />
               </Trigger>
-              <Trigger Property="IsMouseOver" Value="True">
+              <Trigger Property="IsMouseOver" Value="True" >
                 <Setter Property="TextBlock.Foreground" Value="{StaticResource TabMouseOverForegroundBrush}" />
                 <Setter TargetName="Border" Property="Background" Value="{StaticResource TabMouseOverBackgroundBrush}" />
               </Trigger>
-              <Trigger Property="IsSelected" Value="True">
+              <Trigger Property="IsSelected" Value="True" >
                 <Setter Property="Panel.ZIndex" Value="1" />
                 <Setter Property="TextBlock.VerticalAlignment" Value="Center" />
                 <Setter Property="TextBlock.FontWeight" Value="Bold" />
@@ -233,10 +233,10 @@
                 </MultiTrigger.Conditions>
                 <Setter TargetName="Border" Property="BorderThickness" Value="1,1,0,1" />
               </MultiTrigger>
-              <Trigger Property="IsEnabled" Value="True">
+              <Trigger Property="IsEnabled" Value="True" >
                 <Setter TargetName="Border" Property="Cursor" Value="Hand" />
               </Trigger>
-              <Trigger Property="IsEnabled" Value="False">
+              <Trigger Property="IsEnabled" Value="False" >
                 <Setter Property="TextBlock.Foreground" Value="{StaticResource TabDisabledForegroundBrush}" />
                 <Setter TargetName="Border" Property="Background" Value="{StaticResource TabDisabledBackgroundBrush}" />
               </Trigger>
@@ -246,7 +246,7 @@
       </Setter>
     </Style>
   </UserControl.Resources>
-  <Grid Style="{StaticResource GridHooverStyle}" ToolTip="{Binding Description}">
+  <Grid Style="{StaticResource GridHooverStyle}" ToolTip="{Binding Description}" >
     <i:Interaction.Behaviors>
       <behaviors:CommandBehavior Command="{Binding ToggleCheckBoxCommand}" />
       <behaviors:CommandBehavior Command="{Binding DataContext.RecalculateAllIsCheckedCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type documentViews:DocumentsView}}}" />
@@ -261,32 +261,32 @@
       <ColumnDefinition Width="Auto" SharedSizeGroup="LitDate" />
     </Grid.ColumnDefinitions>
 
-    <Border Grid.Column="0" Style="{StaticResource DocumentTableStyle}">
+    <Border Grid.Column="0" Style="{StaticResource DocumentTableStyle}" >
       <CheckBox Margin="10,0,0,0"
                 Command="{Binding DataContext.RecalculateAllIsCheckedCommand,
                                   RelativeSource={RelativeSource FindAncestor,
                                                                  AncestorType={x:Type documentViews:DocumentsView}}}"
                 IsChecked="{Binding IsChecked}" />
     </Border>
-    <Border Grid.Column="1" Style="{StaticResource DocumentTableStyle}">
+    <Border Grid.Column="1" Style="{StaticResource DocumentTableStyle}" >
       <TextBlock Margin="8"
                  HorizontalAlignment="Left"
-                 VerticalAlignment="Center">
-        <Hyperlink Command="{Binding DocumentClickCommand}" Style="{StaticResource HyperlinkStyle}">
+                 VerticalAlignment="Center" >
+        <Hyperlink Command="{Binding DocumentClickCommand}" Style="{StaticResource HyperlinkStyle}" >
           <TextBlock Text="{Binding Title}" />
         </Hyperlink>
       </TextBlock>
     </Border>
-    <Border Grid.Column="2" Style="{StaticResource DocumentTableStyle}">
+    <Border Grid.Column="2" Style="{StaticResource DocumentTableStyle}" >
       <TextBlock Style="{StaticResource DocumentTableTextStyle}" Text="{Binding PrefixedLanguageCode}" />
     </Border>
-    <Border Grid.Column="3" Style="{StaticResource DocumentTableStyle}">
+    <Border Grid.Column="3" Style="{StaticResource DocumentTableStyle}" >
       <TextBlock Style="{StaticResource DocumentTableTextStyle}" Text="{Binding TypeCode}" />
     </Border>
-    <Border Grid.Column="4" Style="{StaticResource DocumentTableStyle}">
+    <Border Grid.Column="4" Style="{StaticResource DocumentTableStyle}" >
       <TextBlock Style="{StaticResource DocumentTableTextStyle}" Text="{Binding DataContext.ProductType, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type documentViews:DocumentsView}}}" />
     </Border>
-    <Border Grid.Column="5" Style="{StaticResource DocumentTableStyle}">
+    <Border Grid.Column="5" Style="{StaticResource DocumentTableStyle}" >
       <TextBlock Style="{StaticResource DocumentTableTextStyle}" Text="{Binding PublishedDate}" />
     </Border>
   </Grid>

--- a/XamlStyler.UnitTests/TestFiles/TestReorderSetterHandling_TargetNameThenProperty.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestReorderSetterHandling_TargetNameThenProperty.expected
@@ -12,28 +12,28 @@
              d:DataContext="{d:DesignInstance documentViewModels:DocumentViewModel}"
              d:DesignHeight="70"
              d:DesignWidth="1024"
-             mc:Ignorable="d">
+             mc:Ignorable="d" >
   <UserControl.Resources>
     <SolidColorBrush x:Key="DocumentForegroundBrush" Color="#333" />
     <SolidColorBrush x:Key="DocumentHoverBrush" Color="#F5F5F5" />
     <SolidColorBrush x:Key="DocumentBorderBrush" Color="#DDD" />
 
     <Style x:Key="EmptySetterStyle" TargetType="Border" />
-    <Style x:Key="SingleSetterStyle" TargetType="Border">
+    <Style x:Key="SingleSetterStyle" TargetType="Border" >
       <!--  Test: Verify that comments are kept  -->
       <Setter Property="BorderBrush" Value="{StaticResource DocumentBorderBrush}" />
       <!--  Test: Verify that comments are kept at bottom  -->
     </Style>
-    <Style x:Key="DocumentTableStyle" TargetType="Border">
+    <Style x:Key="DocumentTableStyle" TargetType="Border" >
       <Setter Property="BorderBrush" Value="{StaticResource DocumentBorderBrush}" />
       <Setter Property="BorderThickness" Value="0.5" />
     </Style>
     <!--  Test: Verify that custom nodes are not reordered despite containing setters  -->
-    <SomeCustomElement x:Key="DocumentTableStyle" TargetType="Border">
+    <SomeCustomElement x:Key="DocumentTableStyle" TargetType="Border" >
       <Setter Property="BorderThickness" Value="0.5" />
       <Setter Property="BorderBrush" Value="{StaticResource DocumentBorderBrush}" />
     </SomeCustomElement>
-    <Style x:Key="DocumentTableTextStyle" TargetType="FrameworkElement">
+    <Style x:Key="DocumentTableTextStyle" TargetType="FrameworkElement" >
       <Setter Property="HorizontalAlignment" Value="Center" />
       <!--  Test: Verify that comments are moved with Margin element  -->
       <Setter Property="Margin" Value="8" />
@@ -42,15 +42,15 @@
       <Setter Property="VerticalAlignment" Value="Center" />
       <!--  Test: Verify that comments are not moved from last position  -->
     </Style>
-    <Style x:Key="GridHooverStyle" TargetType="Grid">
+    <Style x:Key="GridHooverStyle" TargetType="Grid" >
       <Style.Triggers>
-        <Trigger Property="IsMouseOver" Value="True">
+        <Trigger Property="IsMouseOver" Value="True" >
           <Setter Property="Background" Value="{StaticResource DocumentHoverBrush}" />
           <Setter Property="Foreground" Value="{StaticResource DocumentForegroundHoverBrush}" />
         </Trigger>
       </Style.Triggers>
     </Style>
-    <Style x:Key="QuestionDisplayTextStyle" TargetType="TextBlock">
+    <Style x:Key="QuestionDisplayTextStyle" TargetType="TextBlock" >
       <Setter Property="FontFamily" Value="Helvetica Neue,Helvetica,Arial,sans-serif" />
       <Setter Property="FontSize" Value="14" />
       <Setter Property="Foreground" Value="{StaticResource QuestionnaireColorBrush}" />
@@ -60,7 +60,7 @@
       <Setter Property="VerticalAlignment" Value="Center" />
       <!--  Different styling when used from QuickSizing  -->
       <Style.Triggers>
-        <DataTrigger Binding="{Binding QuestionOwnerType}" Value="{x:Type sizingViewModels:QuickSizingViewModel}">
+        <DataTrigger Binding="{Binding QuestionOwnerType}" Value="{x:Type sizingViewModels:QuickSizingViewModel}" >
           <Setter Property="FontStyle" Value="Italic" />
           <Setter Property="HorizontalAlignment" Value="Right" />
           <Setter Property="MaxWidth" Value="100" />
@@ -69,7 +69,7 @@
         <MultiDataTrigger>
           <MultiDataTrigger.Conditions>
             <Condition Binding="{Binding QuestionOwnerType}" Value="{x:Type sizingViewModels:QuickSizingViewModel}" />
-            <Condition Binding="{Binding SettingsViewModel.WindowSize, Source={StaticResource ViewModelLocator}}">
+            <Condition Binding="{Binding SettingsViewModel.WindowSize, Source={StaticResource ViewModelLocator}}" >
               <Condition.Value>
                 <enums:WindowSize>MediumSmall</enums:WindowSize>
               </Condition.Value>
@@ -79,7 +79,7 @@
           <Setter Property="MaxWidth" Value="{x:Static sys:Double.PositiveInfinity}" />
           <Setter Property="TextAlignment" Value="Left" />
         </MultiDataTrigger>
-        <DataTrigger Binding="{Binding SettingsViewModel.WindowSize, Source={StaticResource ViewModelLocator}}">
+        <DataTrigger Binding="{Binding SettingsViewModel.WindowSize, Source={StaticResource ViewModelLocator}}" >
           <DataTrigger.Value>
             <enums:WindowSize>Small</enums:WindowSize>
           </DataTrigger.Value>
@@ -89,19 +89,19 @@
         </DataTrigger>
       </Style.Triggers>
     </Style>
-    <Style TargetType="{x:Type TabControl}">
+    <Style TargetType="{x:Type TabControl}" >
       <Setter Property="Background" Value="{StaticResource TabBackgroundBrush}" />
       <Setter Property="BorderBrush" Value="{StaticResource LightBorderBrush}" />
       <Setter Property="BorderThickness" Value="1" />
       <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
       <Setter Property="HorizontalContentAlignment" Value="Center" />
       <Setter Property="Padding" Value="4,4,4,4" />
-      <Setter Property="Template">
+      <Setter Property="Template" >
         <Setter.Value>
-          <ControlTemplate TargetType="{x:Type TabControl}">
+          <ControlTemplate TargetType="{x:Type TabControl}" >
             <Grid ClipToBounds="true"
                   KeyboardNavigation.TabNavigation="Local"
-                  SnapsToDevicePixels="true">
+                  SnapsToDevicePixels="true" >
               <Grid.ColumnDefinitions>
                 <ColumnDefinition x:Name="ColumnDefinition0" />
                 <ColumnDefinition x:Name="ColumnDefinition1" Width="0" />
@@ -126,7 +126,7 @@
                       BorderThickness="{TemplateBinding BorderThickness}"
                       KeyboardNavigation.DirectionalNavigation="Contained"
                       KeyboardNavigation.TabIndex="2"
-                      KeyboardNavigation.TabNavigation="Local">
+                      KeyboardNavigation.TabNavigation="Local" >
                 <ContentPresenter x:Name="PART_SelectedContentHost"
                                   Margin="{TemplateBinding Padding}"
                                   ContentSource="SelectedContent"
@@ -134,17 +134,17 @@
               </Border>
             </Grid>
             <ControlTemplate.Triggers>
-              <Trigger Property="TabStripPlacement" Value="Top">
+              <Trigger Property="TabStripPlacement" Value="Top" >
                 <!--<Setter Property="Height" TargetName="HeaderPanel" Value="38" />-->
               </Trigger>
-              <Trigger Property="TabStripPlacement" Value="Bottom">
+              <Trigger Property="TabStripPlacement" Value="Bottom" >
                 <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
                 <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="1" />
                 <Setter TargetName="HeaderPanel" Property="Margin" Value="0,-1,0,0" />
                 <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
                 <Setter TargetName="RowDefinition1" Property="Height" Value="Auto" />
               </Trigger>
-              <Trigger Property="TabStripPlacement" Value="Left">
+              <Trigger Property="TabStripPlacement" Value="Left" >
                 <Setter TargetName="ColumnDefinition0" Property="Width" Value="Auto" />
                 <Setter TargetName="ColumnDefinition1" Property="Width" Value="*" />
                 <Setter TargetName="ContentPanel" Property="Grid.Column" Value="1" />
@@ -156,7 +156,7 @@
                 <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
                 <Setter TargetName="RowDefinition1" Property="Height" Value="0" />
               </Trigger>
-              <Trigger Property="TabStripPlacement" Value="Right">
+              <Trigger Property="TabStripPlacement" Value="Right" >
                 <Setter TargetName="ColumnDefinition0" Property="Width" Value="*" />
                 <Setter TargetName="ColumnDefinition1" Property="Width" Value="Auto" />
                 <Setter TargetName="ContentPanel" Property="Grid.Column" Value="0" />
@@ -167,7 +167,7 @@
                 <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
                 <Setter TargetName="RowDefinition1" Property="Height" Value="0" />
               </Trigger>
-              <Trigger Property="IsEnabled" Value="false">
+              <Trigger Property="IsEnabled" Value="false" >
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
               </Trigger>
             </ControlTemplate.Triggers>
@@ -176,18 +176,18 @@
       </Setter>
       <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
-    <Style TargetType="{x:Type TabItem}">
-      <Setter Property="Template">
+    <Style TargetType="{x:Type TabItem}" >
+      <Setter Property="Template" >
         <Setter.Value>
-          <ControlTemplate TargetType="{x:Type TabItem}">
+          <ControlTemplate TargetType="{x:Type TabItem}" >
             <Grid HorizontalAlignment="Stretch"
                   VerticalAlignment="Stretch"
-                  SnapsToDevicePixels="true">
+                  SnapsToDevicePixels="true" >
               <Border Name="Border"
                       Background="{StaticResource TabEnabledBackgroundBrush}"
                       BorderBrush="{StaticResource LightBorderBrush}"
                       BorderThickness="1"
-                      CornerRadius="0">
+                      CornerRadius="0" >
                 <ContentPresenter x:Name="ContentSite"
                                   Margin="15,10,15,10"
                                   HorizontalAlignment="Center"
@@ -197,20 +197,20 @@
               </Border>
             </Grid>
             <ControlTemplate.Triggers>
-              <Trigger Property="TabStripPlacement" Value="Top">
+              <Trigger Property="TabStripPlacement" Value="Top" >
                 <!--<Setter TargetName="ContentSite" Property="Height" Value="38" />-->
                 <Setter TargetName="Border" Property="Margin" Value="0,0,0,-1" />
               </Trigger>
-              <Trigger Property="TabStripPlacement" Value="Left">
+              <Trigger Property="TabStripPlacement" Value="Left" >
                 <Setter TargetName="Border" Property="Margin" Value="0,0,-1,0" />
                 <Setter TargetName="ContentSite" Property="Height" Value="95" />
                 <Setter TargetName="ContentSite" Property="Margin" Value="0" />
               </Trigger>
-              <Trigger Property="IsMouseOver" Value="True">
+              <Trigger Property="IsMouseOver" Value="True" >
                 <Setter Property="TextBlock.Foreground" Value="{StaticResource TabMouseOverForegroundBrush}" />
                 <Setter TargetName="Border" Property="Background" Value="{StaticResource TabMouseOverBackgroundBrush}" />
               </Trigger>
-              <Trigger Property="IsSelected" Value="True">
+              <Trigger Property="IsSelected" Value="True" >
                 <Setter Property="Panel.ZIndex" Value="1" />
                 <Setter Property="TextBlock.FontWeight" Value="Bold" />
                 <Setter Property="TextBlock.Foreground" Value="{StaticResource TabSelectedForegroundBrush}" />
@@ -233,10 +233,10 @@
                 </MultiTrigger.Conditions>
                 <Setter TargetName="Border" Property="BorderThickness" Value="1,1,0,1" />
               </MultiTrigger>
-              <Trigger Property="IsEnabled" Value="True">
+              <Trigger Property="IsEnabled" Value="True" >
                 <Setter TargetName="Border" Property="Cursor" Value="Hand" />
               </Trigger>
-              <Trigger Property="IsEnabled" Value="False">
+              <Trigger Property="IsEnabled" Value="False" >
                 <Setter Property="TextBlock.Foreground" Value="{StaticResource TabDisabledForegroundBrush}" />
                 <Setter TargetName="Border" Property="Background" Value="{StaticResource TabDisabledBackgroundBrush}" />
               </Trigger>
@@ -246,7 +246,7 @@
       </Setter>
     </Style>
   </UserControl.Resources>
-  <Grid Style="{StaticResource GridHooverStyle}" ToolTip="{Binding Description}">
+  <Grid Style="{StaticResource GridHooverStyle}" ToolTip="{Binding Description}" >
     <i:Interaction.Behaviors>
       <behaviors:CommandBehavior Command="{Binding ToggleCheckBoxCommand}" />
       <behaviors:CommandBehavior Command="{Binding DataContext.RecalculateAllIsCheckedCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type documentViews:DocumentsView}}}" />
@@ -261,32 +261,32 @@
       <ColumnDefinition Width="Auto" SharedSizeGroup="LitDate" />
     </Grid.ColumnDefinitions>
 
-    <Border Grid.Column="0" Style="{StaticResource DocumentTableStyle}">
+    <Border Grid.Column="0" Style="{StaticResource DocumentTableStyle}" >
       <CheckBox Margin="10,0,0,0"
                 Command="{Binding DataContext.RecalculateAllIsCheckedCommand,
                                   RelativeSource={RelativeSource FindAncestor,
                                                                  AncestorType={x:Type documentViews:DocumentsView}}}"
                 IsChecked="{Binding IsChecked}" />
     </Border>
-    <Border Grid.Column="1" Style="{StaticResource DocumentTableStyle}">
+    <Border Grid.Column="1" Style="{StaticResource DocumentTableStyle}" >
       <TextBlock Margin="8"
                  HorizontalAlignment="Left"
-                 VerticalAlignment="Center">
-        <Hyperlink Command="{Binding DocumentClickCommand}" Style="{StaticResource HyperlinkStyle}">
+                 VerticalAlignment="Center" >
+        <Hyperlink Command="{Binding DocumentClickCommand}" Style="{StaticResource HyperlinkStyle}" >
           <TextBlock Text="{Binding Title}" />
         </Hyperlink>
       </TextBlock>
     </Border>
-    <Border Grid.Column="2" Style="{StaticResource DocumentTableStyle}">
+    <Border Grid.Column="2" Style="{StaticResource DocumentTableStyle}" >
       <TextBlock Style="{StaticResource DocumentTableTextStyle}" Text="{Binding PrefixedLanguageCode}" />
     </Border>
-    <Border Grid.Column="3" Style="{StaticResource DocumentTableStyle}">
+    <Border Grid.Column="3" Style="{StaticResource DocumentTableStyle}" >
       <TextBlock Style="{StaticResource DocumentTableTextStyle}" Text="{Binding TypeCode}" />
     </Border>
-    <Border Grid.Column="4" Style="{StaticResource DocumentTableStyle}">
+    <Border Grid.Column="4" Style="{StaticResource DocumentTableStyle}" >
       <TextBlock Style="{StaticResource DocumentTableTextStyle}" Text="{Binding DataContext.ProductType, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type documentViews:DocumentsView}}}" />
     </Border>
-    <Border Grid.Column="5" Style="{StaticResource DocumentTableStyle}">
+    <Border Grid.Column="5" Style="{StaticResource DocumentTableStyle}" >
       <TextBlock Style="{StaticResource DocumentTableTextStyle}" Text="{Binding PublishedDate}" />
     </Border>
   </Grid>

--- a/XamlStyler.UnitTests/TestFiles/TestRootHandling_1.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestRootHandling_1.expected
@@ -2,10 +2,10 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:system="clr-namespace:System;assembly=mscorlib" xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
         Title="{Binding Title}"
-        Width="525" Height="350">
+        Width="525" Height="350" >
   <DockPanel Grid.Row="0" Grid.RowSpan="1" Grid.Column="0" Grid.ColumnSpan="1"
              Width="Auto" Height="Auto" Margin="0,0,0,0"
-             HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+             HorizontalAlignment="Stretch" VerticalAlignment="Stretch" >
     <StackPanel />
   </DockPanel>
 </Window>

--- a/XamlStyler.UnitTests/TestFiles/TestRootHandling_2.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestRootHandling_2.expected
@@ -5,10 +5,10 @@
         xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
         Title="{Binding Title}"
         Width="525"
-        Height="350">
+        Height="350" >
   <DockPanel Grid.Row="0" Grid.RowSpan="1" Grid.Column="0" Grid.ColumnSpan="1"
              Width="Auto" Height="Auto" Margin="0,0,0,0"
-             HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+             HorizontalAlignment="Stretch" VerticalAlignment="Stretch" >
     <StackPanel />
   </DockPanel>
 </Window>

--- a/XamlStyler.UnitTests/TestFiles/TestRootHandling_3.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestRootHandling_3.expected
@@ -1,7 +1,7 @@
-﻿<Window x:Class="Test.MainWindow" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib" xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit" Title="{Binding Title}" Width="525" Height="350">
+﻿<Window x:Class="Test.MainWindow" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib" xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit" Title="{Binding Title}" Width="525" Height="350" >
   <DockPanel Grid.Row="0" Grid.RowSpan="1" Grid.Column="0" Grid.ColumnSpan="1"
              Width="Auto" Height="Auto" Margin="0,0,0,0"
-             HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+             HorizontalAlignment="Stretch" VerticalAlignment="Stretch" >
     <StackPanel />
   </DockPanel>
 </Window>

--- a/XamlStyler.UnitTests/TestFiles/TestRunHandling.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestRunHandling.expected
@@ -5,7 +5,7 @@
         xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
         Title="{Binding Title}"
         Width="525"
-        Height="350">
+        Height="350" >
   <DockPanel Grid.Row="0"
              Grid.RowSpan="1"
              Grid.Column="0"
@@ -14,7 +14,7 @@
              Height="Auto"
              Margin="0,0,0,0"
              HorizontalAlignment="Stretch"
-             VerticalAlignment="Stretch">
+             VerticalAlignment="Stretch" >
     <StackPanel>
       <!--  one liners  -->
       <TextBlock><Run>A</Run></TextBlock>
@@ -29,12 +29,12 @@
         <Run>C</Run> <Run>D</Run>
       </TextBlock>
       <!--  preserve with xml:space  -->
-      <TextBlock xml:space="preserve"><Run>A</Run></TextBlock>
-      <TextBlock xml:space="preserve"><Run>A</Run><Run>B</Run></TextBlock>
-      <TextBlock xml:space="preserve">
+      <TextBlock xml:space="preserve" ><Run>A</Run></TextBlock>
+      <TextBlock xml:space="preserve" ><Run>A</Run><Run>B</Run></TextBlock>
+      <TextBlock xml:space="preserve" >
     <Run>C</Run><Run>D</Run>
   </TextBlock>
-      <TextBlock xml:space="preserve">
+      <TextBlock xml:space="preserve" >
     <Run>E</Run> <Run>F</Run>
   </TextBlock>
       <!--  No significant whitespace  -->

--- a/XamlStyler.UnitTests/TestFiles/TestTextOnlyContentElementHandling.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestTextOnlyContentElementHandling.expected
@@ -6,10 +6,10 @@
   <SingleTab />
   <SingleAmp>&amp;</SingleAmp>
   <SingleLine>test here</SingleLine>
-  <SingleLine a="a" b="b">test here</SingleLine>
+  <SingleLine a="a" b="b" >test here</SingleLine>
   <SingleLineWithLinefeed a="a"
                           b="b"
-                          c="c">
+                          c="c" >
     line
   </SingleLineWithLinefeed>
   <MultipleSpaces />

--- a/XamlStyler.UnitTests/TestFiles/TestThicknessHandling_Comma.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestThicknessHandling_Comma.expected
@@ -6,12 +6,12 @@
         Title="{Binding Title}"
         Width="525"
         Height="350"
-        Padding="3,2">
+        Padding="3,2" >
   <Window.Resources>
-    <Style TargetType="TextBox">
+    <Style TargetType="TextBox" >
       <Setter Property="Text" Value="Default Text &amp;&lt;" />
       <Style.Triggers>
-        <Trigger Property="IsEnabled" Value="false">
+        <Trigger Property="IsEnabled" Value="false" >
           <Setter Property="Margin" Value="2" />
           <Setter Property="Padding" Value="2,4" />
         </Trigger>
@@ -26,7 +26,7 @@
              Height="Auto"
              Margin="0,0,0,0"
              HorizontalAlignment="Stretch"
-             VerticalAlignment="Stretch">
+             VerticalAlignment="Stretch" >
     <StackPanel>
       <TextBox Margin="1,2,3,4" />
     </StackPanel>

--- a/XamlStyler.UnitTests/TestFiles/TestThicknessHandling_None.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestThicknessHandling_None.expected
@@ -6,12 +6,12 @@
         Title="{Binding Title}"
         Width="525"
         Height="350"
-        Padding="3,2 ">
+        Padding="3,2 " >
   <Window.Resources>
-    <Style TargetType="TextBox">
+    <Style TargetType="TextBox" >
       <Setter Property="Text" Value="Default Text &amp;&lt;" />
       <Style.Triggers>
-        <Trigger Property="IsEnabled" Value="false">
+        <Trigger Property="IsEnabled" Value="false" >
           <Setter Property="Margin" Value=" 2" />
           <Setter Property="Padding" Value=" 2,4 " />
         </Trigger>
@@ -26,7 +26,7 @@
              Height="Auto"
              Margin="0,0,0,0"
              HorizontalAlignment="Stretch"
-             VerticalAlignment="Stretch">
+             VerticalAlignment="Stretch" >
     <StackPanel>
       <TextBox Margin="1 2 3 4" />
     </StackPanel>

--- a/XamlStyler.UnitTests/TestFiles/TestThicknessHandling_Space.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestThicknessHandling_Space.expected
@@ -6,12 +6,12 @@
         Title="{Binding Title}"
         Width="525"
         Height="350"
-        Padding="3 2">
+        Padding="3 2" >
   <Window.Resources>
-    <Style TargetType="TextBox">
+    <Style TargetType="TextBox" >
       <Setter Property="Text" Value="Default Text &amp;&lt;" />
       <Style.Triggers>
-        <Trigger Property="IsEnabled" Value="false">
+        <Trigger Property="IsEnabled" Value="false" >
           <Setter Property="Margin" Value="2" />
           <Setter Property="Padding" Value="2 4" />
         </Trigger>
@@ -26,7 +26,7 @@
              Height="Auto"
              Margin="0 0 0 0"
              HorizontalAlignment="Stretch"
-             VerticalAlignment="Stretch">
+             VerticalAlignment="Stretch" >
     <StackPanel>
       <TextBox Margin="1 2 3 4" />
     </StackPanel>

--- a/XamlStyler.UnitTests/TestFiles/TestValueXmlEntityHandling.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestValueXmlEntityHandling.expected
@@ -12,9 +12,9 @@
              d:DataContext="{d:DesignInstance documentViewModels:DocumentViewModel}"
              d:DesignHeight="70"
              d:DesignWidth="1024"
-             mc:Ignorable="d">
+             mc:Ignorable="d" >
   <UserControl.Resources>
-    <Style x:Key="QuestionDisplayTextStyle" TargetType="TextBlock">
+    <Style x:Key="QuestionDisplayTextStyle" TargetType="TextBlock" >
       <Setter Property="FontFamily" Value="Helvetica Neue,Helvetica,Arial,sans-serif" />
       <Setter Property="FontSize" Value="14" />
       <Setter Property="Foreground" Value="{StaticResource QuestionnaireColorBrush}" />

--- a/XamlStyler.UnitTests/TestFiles/TestVisualStateManagerFirst.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestVisualStateManagerFirst.expected
@@ -1,10 +1,10 @@
 ﻿<Page x:Class="XamlMagic.TestVisualStateManager"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:local="using:XamlMagic">
+      xmlns:local="using:XamlMagic" >
   <Page.Resources>
     <!--  Default style for Windows.UI.Xaml.Controls.Button  -->
-    <Style TargetType="Button">
+    <Style TargetType="Button" >
       <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
       <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
       <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundTransparentBrush}" />
@@ -16,51 +16,51 @@
       <Setter Property="FontWeight" Value="Normal" />
       <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
       <Setter Property="UseSystemFocusVisuals" Value="True" />
-      <Setter Property="Template">
+      <Setter Property="Template" >
         <Setter.Value>
-          <ControlTemplate TargetType="Button">
-            <Grid x:Name="RootGrid" Background="{TemplateBinding Background}">
+          <ControlTemplate TargetType="Button" >
+            <Grid x:Name="RootGrid" Background="{TemplateBinding Background}" >
               <VisualStateManager.VisualStateGroups>
-                <VisualStateGroup x:Name="CommonStates">
-                  <VisualState x:Name="Normal">
+                <VisualStateGroup x:Name="CommonStates" >
+                  <VisualState x:Name="Normal" >
                     <Storyboard>
                       <PointerUpThemeAnimation Storyboard.TargetName="RootGrid" />
                     </Storyboard>
                   </VisualState>
-                  <VisualState x:Name="PointerOver">
+                  <VisualState x:Name="PointerOver" >
                     <Storyboard>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightBaseMediumLowBrush}" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightBaseHighBrush}" />
                       </ObjectAnimationUsingKeyFrames>
                       <PointerUpThemeAnimation Storyboard.TargetName="RootGrid" />
                     </Storyboard>
                   </VisualState>
-                  <VisualState x:Name="Pressed">
+                  <VisualState x:Name="Pressed" >
                     <Storyboard>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlBackgroundBaseMediumLowBrush}" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightTransparentBrush}" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightBaseHighBrush}" />
                       </ObjectAnimationUsingKeyFrames>
                       <PointerDownThemeAnimation Storyboard.TargetName="RootGrid" />
                     </Storyboard>
                   </VisualState>
-                  <VisualState x:Name="Disabled">
+                  <VisualState x:Name="Disabled" >
                     <Storyboard>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlDisabledTransparentBrush}" />
                       </ObjectAnimationUsingKeyFrames>
                     </Storyboard>
@@ -82,7 +82,7 @@
         </Setter.Value>
       </Setter>
     </Style>
-    <Style TargetType="Button">
+    <Style TargetType="Button" >
       <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
       <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
       <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundTransparentBrush}" />
@@ -94,55 +94,55 @@
       <Setter Property="FontWeight" Value="Normal" />
       <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
       <Setter Property="UseSystemFocusVisuals" Value="True" />
-      <Setter Property="Template">
+      <Setter Property="Template" >
         <Setter.Value>
-          <ControlTemplate TargetType="Button">
-            <Grid x:Name="RootGrid" Background="{TemplateBinding Background}">
+          <ControlTemplate TargetType="Button" >
+            <Grid x:Name="RootGrid" Background="{TemplateBinding Background}" >
               <Grid.RowDefinition>
                 <RowDefinition />
                 <RowDefinition />
               </Grid.RowDefinition>
               <VisualStateManager.VisualStateGroups>
-                <VisualStateGroup x:Name="CommonStates">
-                  <VisualState x:Name="Normal">
+                <VisualStateGroup x:Name="CommonStates" >
+                  <VisualState x:Name="Normal" >
                     <Storyboard>
                       <PointerUpThemeAnimation Storyboard.TargetName="RootGrid" />
                     </Storyboard>
                   </VisualState>
-                  <VisualState x:Name="PointerOver">
+                  <VisualState x:Name="PointerOver" >
                     <Storyboard>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightBaseMediumLowBrush}" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightBaseHighBrush}" />
                       </ObjectAnimationUsingKeyFrames>
                       <PointerUpThemeAnimation Storyboard.TargetName="RootGrid" />
                     </Storyboard>
                   </VisualState>
-                  <VisualState x:Name="Pressed">
+                  <VisualState x:Name="Pressed" >
                     <Storyboard>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlBackgroundBaseMediumLowBrush}" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightTransparentBrush}" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightBaseHighBrush}" />
                       </ObjectAnimationUsingKeyFrames>
                       <PointerDownThemeAnimation Storyboard.TargetName="RootGrid" />
                     </Storyboard>
                   </VisualState>
-                  <VisualState x:Name="Disabled">
+                  <VisualState x:Name="Disabled" >
                     <Storyboard>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlDisabledTransparentBrush}" />
                       </ObjectAnimationUsingKeyFrames>
                     </Storyboard>

--- a/XamlStyler.UnitTests/TestFiles/TestVisualStateManagerLast.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestVisualStateManagerLast.expected
@@ -1,10 +1,10 @@
 ﻿<Page x:Class="XamlMagic.TestVisualStateManager"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:local="using:XamlMagic">
+      xmlns:local="using:XamlMagic" >
   <Page.Resources>
     <!--  Default style for Windows.UI.Xaml.Controls.Button  -->
-    <Style TargetType="Button">
+    <Style TargetType="Button" >
       <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
       <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
       <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundTransparentBrush}" />
@@ -16,10 +16,10 @@
       <Setter Property="FontWeight" Value="Normal" />
       <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
       <Setter Property="UseSystemFocusVisuals" Value="True" />
-      <Setter Property="Template">
+      <Setter Property="Template" >
         <Setter.Value>
-          <ControlTemplate TargetType="Button">
-            <Grid x:Name="RootGrid" Background="{TemplateBinding Background}">
+          <ControlTemplate TargetType="Button" >
+            <Grid x:Name="RootGrid" Background="{TemplateBinding Background}" >
               <ContentPresenter x:Name="ContentPresenter"
                                 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -31,46 +31,46 @@
                                 ContentTransitions="{TemplateBinding ContentTransitions}"
                                 Padding="{TemplateBinding Padding}" />
               <VisualStateManager.VisualStateGroups>
-                <VisualStateGroup x:Name="CommonStates">
-                  <VisualState x:Name="Normal">
+                <VisualStateGroup x:Name="CommonStates" >
+                  <VisualState x:Name="Normal" >
                     <Storyboard>
                       <PointerUpThemeAnimation Storyboard.TargetName="RootGrid" />
                     </Storyboard>
                   </VisualState>
-                  <VisualState x:Name="PointerOver">
+                  <VisualState x:Name="PointerOver" >
                     <Storyboard>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightBaseMediumLowBrush}" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightBaseHighBrush}" />
                       </ObjectAnimationUsingKeyFrames>
                       <PointerUpThemeAnimation Storyboard.TargetName="RootGrid" />
                     </Storyboard>
                   </VisualState>
-                  <VisualState x:Name="Pressed">
+                  <VisualState x:Name="Pressed" >
                     <Storyboard>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlBackgroundBaseMediumLowBrush}" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightTransparentBrush}" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightBaseHighBrush}" />
                       </ObjectAnimationUsingKeyFrames>
                       <PointerDownThemeAnimation Storyboard.TargetName="RootGrid" />
                     </Storyboard>
                   </VisualState>
-                  <VisualState x:Name="Disabled">
+                  <VisualState x:Name="Disabled" >
                     <Storyboard>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlDisabledTransparentBrush}" />
                       </ObjectAnimationUsingKeyFrames>
                     </Storyboard>

--- a/XamlStyler.UnitTests/TestFiles/TestVisualStateManagerNone.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestVisualStateManagerNone.expected
@@ -1,10 +1,10 @@
 ﻿<Page x:Class="XamlMagic.TestVisualStateManager"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:local="using:XamlMagic">
+      xmlns:local="using:XamlMagic" >
   <Page.Resources>
     <!--  Default style for Windows.UI.Xaml.Controls.Button  -->
-    <Style TargetType="Button">
+    <Style TargetType="Button" >
       <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
       <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
       <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundTransparentBrush}" />
@@ -16,10 +16,10 @@
       <Setter Property="FontWeight" Value="Normal" />
       <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
       <Setter Property="UseSystemFocusVisuals" Value="True" />
-      <Setter Property="Template">
+      <Setter Property="Template" >
         <Setter.Value>
-          <ControlTemplate TargetType="Button">
-            <Grid x:Name="RootGrid" Background="{TemplateBinding Background}">
+          <ControlTemplate TargetType="Button" >
+            <Grid x:Name="RootGrid" Background="{TemplateBinding Background}" >
               <ContentPresenter x:Name="ContentPresenter"
                                 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -31,46 +31,46 @@
                                 ContentTransitions="{TemplateBinding ContentTransitions}"
                                 Padding="{TemplateBinding Padding}" />
               <VisualStateManager.VisualStateGroups>
-                <VisualStateGroup x:Name="CommonStates">
-                  <VisualState x:Name="Normal">
+                <VisualStateGroup x:Name="CommonStates" >
+                  <VisualState x:Name="Normal" >
                     <Storyboard>
                       <PointerUpThemeAnimation Storyboard.TargetName="RootGrid" />
                     </Storyboard>
                   </VisualState>
-                  <VisualState x:Name="PointerOver">
+                  <VisualState x:Name="PointerOver" >
                     <Storyboard>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightBaseMediumLowBrush}" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightBaseHighBrush}" />
                       </ObjectAnimationUsingKeyFrames>
                       <PointerUpThemeAnimation Storyboard.TargetName="RootGrid" />
                     </Storyboard>
                   </VisualState>
-                  <VisualState x:Name="Pressed">
+                  <VisualState x:Name="Pressed" >
                     <Storyboard>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlBackgroundBaseMediumLowBrush}" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightTransparentBrush}" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightBaseHighBrush}" />
                       </ObjectAnimationUsingKeyFrames>
                       <PointerDownThemeAnimation Storyboard.TargetName="RootGrid" />
                     </Storyboard>
                   </VisualState>
-                  <VisualState x:Name="Disabled">
+                  <VisualState x:Name="Disabled" >
                     <Storyboard>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlDisabledTransparentBrush}" />
                       </ObjectAnimationUsingKeyFrames>
                     </Storyboard>
@@ -82,7 +82,7 @@
         </Setter.Value>
       </Setter>
     </Style>
-    <Style TargetType="Button">
+    <Style TargetType="Button" >
       <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
       <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
       <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundTransparentBrush}" />
@@ -94,51 +94,51 @@
       <Setter Property="FontWeight" Value="Normal" />
       <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
       <Setter Property="UseSystemFocusVisuals" Value="True" />
-      <Setter Property="Template">
+      <Setter Property="Template" >
         <Setter.Value>
-          <ControlTemplate TargetType="Button">
-            <Grid x:Name="RootGrid" Background="{TemplateBinding Background}">
+          <ControlTemplate TargetType="Button" >
+            <Grid x:Name="RootGrid" Background="{TemplateBinding Background}" >
               <VisualStateManager.VisualStateGroups>
-                <VisualStateGroup x:Name="CommonStates">
-                  <VisualState x:Name="Normal">
+                <VisualStateGroup x:Name="CommonStates" >
+                  <VisualState x:Name="Normal" >
                     <Storyboard>
                       <PointerUpThemeAnimation Storyboard.TargetName="RootGrid" />
                     </Storyboard>
                   </VisualState>
-                  <VisualState x:Name="PointerOver">
+                  <VisualState x:Name="PointerOver" >
                     <Storyboard>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightBaseMediumLowBrush}" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightBaseHighBrush}" />
                       </ObjectAnimationUsingKeyFrames>
                       <PointerUpThemeAnimation Storyboard.TargetName="RootGrid" />
                     </Storyboard>
                   </VisualState>
-                  <VisualState x:Name="Pressed">
+                  <VisualState x:Name="Pressed" >
                     <Storyboard>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlBackgroundBaseMediumLowBrush}" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightTransparentBrush}" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightBaseHighBrush}" />
                       </ObjectAnimationUsingKeyFrames>
                       <PointerDownThemeAnimation Storyboard.TargetName="RootGrid" />
                     </Storyboard>
                   </VisualState>
-                  <VisualState x:Name="Disabled">
+                  <VisualState x:Name="Disabled" >
                     <Storyboard>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush" >
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlDisabledTransparentBrush}" />
                       </ObjectAnimationUsingKeyFrames>
                     </Storyboard>

--- a/XamlStyler.UnitTests/TestFiles/TestWildcard.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestWildcard.expected
@@ -1,6 +1,6 @@
 ﻿<Window x:Class="MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" >
   <Grid>
     <Button Grid.Column="1"
             Grid.Row="1"

--- a/XamlStyler.UnitTests/TestFiles/TestXmlSpaceHandling.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestXmlSpaceHandling.expected
@@ -1,22 +1,22 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:system="clr-namespace:System;assembly=mscorlib">
-  <system:String x:Key="Greeting1">
+                    xmlns:system="clr-namespace:System;assembly=mscorlib" >
+  <system:String x:Key="Greeting1" >
     Hello
     World
   </system:String>
-  <system:String x:Key="Greeting2" xml:space="preserve">Hello
+  <system:String x:Key="Greeting2" xml:space="preserve" >Hello
 World</system:String>
-  <system:String x:Key="Greeting3" xml:space="preserve"> Hello World </system:String>
-  <system:String x:Key="Greeting4" xml:space="preserve"> Hello 
+  <system:String x:Key="Greeting3" xml:space="preserve" > Hello World </system:String>
+  <system:String x:Key="Greeting4" xml:space="preserve" > Hello 
  World </system:String>
-  <system:String x:Key="Greeting5" xml:space="preserve">Hello World</system:String>
-  <system:String x:Key="Greeting6" xml:space="default">
+  <system:String x:Key="Greeting5" xml:space="preserve" >Hello World</system:String>
+  <system:String x:Key="Greeting6" xml:space="default" >
     Hello
     World
   </system:String>
-  <system:String x:Key="Lyric1" xml:space="preserve"> Mary had a little lamb, Its fleece was <strong>white</strong> as snow </system:String>
-  <system:String x:Key="Lyric2" xml:space="preserve">
+  <system:String x:Key="Lyric1" xml:space="preserve" > Mary had a little lamb, Its fleece was <strong>white</strong> as snow </system:String>
+  <system:String x:Key="Lyric2" xml:space="preserve" >
   Mary had a little lamb, Its fleece was <strong>white</strong> as snow 
 </system:String>
 </ResourceDictionary>

--- a/XamlStyler.UnitTests/TestFiles/TestxBindSplitting.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestxBindSplitting.expected
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="MainWindow"
         Width="525"
-        Height="350">
+        Height="350" >
   <Grid>
     <TextBlock FontFamily="Arial"
                FontSize="18"


### PR DESCRIPTION
…self-closing elements")

- If "Space before ending slash in self-closing elements" is "True", and the '>' is not on its own line and there are attributes then put a space between the last attribute end-quote and the close tag '>'.