### PR TITLE
Save all 'only' opened documents

### DIFF
--- a/XamlStyler.Core/Options/IStylerOptions.cs
+++ b/XamlStyler.Core/Options/IStylerOptions.cs
@@ -97,6 +97,8 @@ namespace Xavalon.XamlStyler.Core.Options
 
         bool BeautifyOnSave { get; set; }
 
+        bool BeautifyOpenedOnlyOnSave { get; set; }
+
         int CommentSpaces { get; set; }
 
         #endregion Misc

--- a/XamlStyler.Core/Options/StylerOptions.cs
+++ b/XamlStyler.Core/Options/StylerOptions.cs
@@ -264,6 +264,13 @@ namespace Xavalon.XamlStyler.Core.Options
         public bool BeautifyOnSave { get; set; }
 
         [Category("Misc")]
+        [DisplayName("Format XAML of opened documents only on save")]
+        [JsonProperty("FormatOpenedOnlyOnSave", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [Description("Defines whether to automatically format opened XAML document while saving.\r\n\r\nDefault Value: false")]
+        [DefaultValue(true)]
+        public bool BeautifyOpenedOnlyOnSave { get; set; }
+
+        [Category("Misc")]
         [DisplayName("Comment padding")]
         [JsonProperty("CommentPadding", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         [Description("Determines the number of spaces a XAML comment should be padded with.\r\n\r\nDefault Value: 2")]
@@ -309,7 +316,7 @@ namespace Xavalon.XamlStyler.Core.Options
             {
                 this.configPath = value;
 
-                if(!String.IsNullOrEmpty(value))
+                if (!String.IsNullOrEmpty(value))
                 {
                     this.TryLoadExternalConfiguration();
                 }
@@ -388,7 +395,7 @@ namespace Xavalon.XamlStyler.Core.Options
                             {
                                 indentSize = -1;
                             }
-                            
+
 
                             // Cannot specify MissingMemberHandling for a single property, so relying on JSON default
                             // value to detect missing member, and setting default on detection.

--- a/XamlStyler2.Package/DocumentExtensions.cs
+++ b/XamlStyler2.Package/DocumentExtensions.cs
@@ -1,0 +1,19 @@
+﻿using EnvDTE;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Xavalon.XamlStyler.Package
+{
+    public static class DocumentExtensions
+    {
+        public static IEnumerable<Document> OpenedOnly(this IEnumerable<Document> source, bool openedOnly)
+        {
+            if (openedOnly)
+            {
+                source = source.Where(d => d.ActiveWindow != null);
+            }
+
+            return source;
+        }
+    }
+}

--- a/XamlStyler2.Package/StylerPackage.cs
+++ b/XamlStyler2.Package/StylerPackage.cs
@@ -140,26 +140,20 @@ namespace Xavalon.XamlStyler.Package
         {
             // use parallel processing, but only on the documents that are formatable
             // (to avoid the overhead of Task creating when it's not necessary)
-
-            List<Document> docs = new List<Document>();
-            foreach (Document document in _dte.Documents)
+            IStylerOptions options = GetDialogPage(typeof(PackageOptions)).AutomationObject as IStylerOptions;
+            if (options.BeautifyOnSave)
             {
-                if (IsFormatableDocument(document))
-                {
-                    docs.Add(document);
-                }
+                IEnumerable<Document> docs = GetFormatableDocuments().OpenedOnly(options.BeautifyOpenedOnlyOnSave);
+
+                Parallel.ForEach(docs, Execute);
             }
+        }
 
-            Parallel.ForEach(docs, document =>
-                {
-                    var options = GetDialogPage(typeof(PackageOptions)).AutomationObject as IStylerOptions;
-
-                    if (options.BeautifyOnSave)
-                    {
-                        Execute(document);
-                    }
-                }
-                );
+        private IEnumerable<Document> GetFormatableDocuments()
+        {
+            return _dte.Documents
+                       .Cast<Document>()
+                       .Where(IsFormatableDocument);
         }
 
         private void Execute(Document document)
@@ -194,7 +188,7 @@ namespace Xavalon.XamlStyler.Package
             StylerService styler = new StylerService(stylerOptions);
 
             var textDocument = (TextDocument)document.Object("TextDocument");
-            
+
             EditPoint startPoint = textDocument.StartPoint.CreateEditPoint();
             EditPoint endPoint = textDocument.EndPoint.CreateEditPoint();
 

--- a/XamlStyler2.Package/XamlStyler2.Package.csproj
+++ b/XamlStyler2.Package/XamlStyler2.Package.csproj
@@ -150,6 +150,7 @@
     </COMReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DocumentExtensions.cs" />
     <Compile Include="Guids.cs" />
     <Compile Include="PackageOptions.cs">
       <SubType>Component</SubType>

--- a/XamlStyler3.Package/DocumentExtensions.cs
+++ b/XamlStyler3.Package/DocumentExtensions.cs
@@ -1,0 +1,19 @@
+﻿using EnvDTE;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Xavalon.XamlStyler3.Package
+{
+    public static class DocumentExtensions
+    {
+        public static IEnumerable<Document> OpenedOnly(this IEnumerable<Document> source, bool openedOnly)
+        {
+            if (openedOnly)
+            {
+                source = source.Where(d => d.ActiveWindow != null);
+            }
+
+            return source;
+        }
+    }
+}

--- a/XamlStyler3.Package/StylerPackage.cs
+++ b/XamlStyler3.Package/StylerPackage.cs
@@ -35,12 +35,12 @@ namespace Xavalon.XamlStyler3.Package
         private CommandEvents _fileSaveAll;
         private CommandEvents _fileSaveSelectedItems;
         private IVsUIShell _uiShell;
-        
+
         public StylerPackage()
         {
             Trace.WriteLine(string.Format(CultureInfo.CurrentCulture, "Entering constructor for: {0}", ToString()));
         }
-        
+
         protected override void Initialize()
         {
             Trace.WriteLine(string.Format(CultureInfo.CurrentCulture, "Entering Initialize() of: {0}", ToString()));
@@ -116,26 +116,20 @@ namespace Xavalon.XamlStyler3.Package
         {
             // use parallel processing, but only on the documents that are formatable
             // (to avoid the overhead of Task creating when it's not necessary)
-
-            List<Document> docs = new List<Document>();
-            foreach (Document document in _dte.Documents)
+            IStylerOptions options = GetDialogPage(typeof(PackageOptions)).AutomationObject as IStylerOptions;
+            if (options.BeautifyOnSave)
             {
-                if (IsFormatableDocument(document))
-                {
-                    docs.Add(document);
-                }
-            }
+                IEnumerable<Document> docs = GetFormatableDocuments().OpenedOnly(options.BeautifyOpenedOnlyOnSave);
 
-            Parallel.ForEach(docs, document =>
-            {
-                var options = GetDialogPage(typeof(PackageOptions)).AutomationObject as IStylerOptions;
-
-                if (options.BeautifyOnSave)
-                {
-                    Execute(document);
-                }
+                Parallel.ForEach(docs, Execute);
             }
-                );
+        }
+
+        private IEnumerable<Document> GetFormatableDocuments()
+        {
+            return _dte.Documents
+                       .Cast<Document>()
+                       .Where(IsFormatableDocument);
         }
 
         private void Execute(Document document)
@@ -177,7 +171,7 @@ namespace Xavalon.XamlStyler3.Package
             StylerService styler = new StylerService(stylerOptions);
 
             var textDocument = (TextDocument)document.Object("TextDocument");
-            
+
             EditPoint startPoint = textDocument.StartPoint.CreateEditPoint();
             EditPoint endPoint = textDocument.EndPoint.CreateEditPoint();
 

--- a/XamlStyler3.Package/XamlStyler3.Package.csproj
+++ b/XamlStyler3.Package/XamlStyler3.Package.csproj
@@ -137,6 +137,7 @@
     </COMReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DocumentExtensions.cs" />
     <Compile Include="Guids.cs" />
     <Compile Include="PackageOptions.cs">
       <SubType>Component</SubType>


### PR DESCRIPTION
This should add option to settings to allow format only opened documents in case "Save all" command is triggered.
#142 