### PR TITLE
SearchToDriveRoot Feature

### DIFF
--- a/XamlStyler.Core/Options/DefaultSettings.json
+++ b/XamlStyler.Core/Options/DefaultSettings.json
@@ -38,4 +38,5 @@
     "ThicknessAttributes": "Margin, Padding, BorderThickness, ThumbnailClipMargin",
     "FormatOnSave": true,
     "CommentPadding": 2,
+    "SearchToDriveRoot": true,
 }

--- a/XamlStyler.Core/Options/IStylerOptions.cs
+++ b/XamlStyler.Core/Options/IStylerOptions.cs
@@ -105,7 +105,7 @@ namespace Xavalon.XamlStyler.Core.Options
 
         string ConfigPath { get; set; }
 
-        bool SearchToDrivesRoot { get; set; }
+        bool SearchToDriveRoot { get; set; }
 
         bool ResetToDefault { get; set; }
 

--- a/XamlStyler.Core/Options/IStylerOptions.cs
+++ b/XamlStyler.Core/Options/IStylerOptions.cs
@@ -105,6 +105,8 @@ namespace Xavalon.XamlStyler.Core.Options
 
         string ConfigPath { get; set; }
 
+        bool SearchToDriveRoot { get; set; }
+
         bool ResetToDefault { get; set; }
 
         bool SuppressProcessing { get; set; }

--- a/XamlStyler.Core/Options/StylerOptions.cs
+++ b/XamlStyler.Core/Options/StylerOptions.cs
@@ -276,9 +276,9 @@ namespace Xavalon.XamlStyler.Core.Options
         [RefreshProperties(RefreshProperties.All)]
         [DisplayName("Search to drives root")]
         [Description("When set to true, XAML Styler will look for an external XAML Styler configuration file not only up through your solution directory, but up through the drives root of the current solution so you can share one configuration file through multiple solutions.\r\n\r\nDefault Value: true")]
-        [DefaultValue(true)]
+        [DefaultValue(false)]
         [JsonIgnore]
-        public bool SearchToDrivesRoot { get; set; }
+        public bool SearchToDriveRoot { get; set; }
 
         private bool resetToDefault;
 

--- a/XamlStyler.Core/Options/StylerOptions.cs
+++ b/XamlStyler.Core/Options/StylerOptions.cs
@@ -271,6 +271,15 @@ namespace Xavalon.XamlStyler.Core.Options
         public int CommentSpaces { get; set; }
 
         // Configuration
+
+        [Category("XAML Styler Configuration")]
+        [RefreshProperties(RefreshProperties.All)]
+        [DisplayName("Search to drives root")]
+        [Description("When set to true, XAML Styler will look for an external XAML Styler configuration file not only up through your solution directory, but up through the drives root of the current solution so you can share one configuration file through multiple solutions.\r\n\r\nDefault Value: true")]
+        [DefaultValue(false)]
+        [JsonIgnore]
+        public bool SearchToDriveRoot { get; set; }
+
         private bool resetToDefault;
 
         [Category("XAML Styler Configuration")]

--- a/XamlStyler.UnitTests/FileHandlingIntegrationTests.cs
+++ b/XamlStyler.UnitTests/FileHandlingIntegrationTests.cs
@@ -71,6 +71,7 @@ namespace Xavalon.XamlStyler.UnitTests
         }
 
         [TestCase(0)]
+        [TestCase(0)]
         [TestCase(1)]
         [TestCase(2)]
         [TestCase(3)]

--- a/XamlStyler3.Package/StylerPackage.cs
+++ b/XamlStyler3.Package/StylerPackage.cs
@@ -151,7 +151,7 @@ namespace Xavalon.XamlStyler3.Package
 
             var solutionPath = String.IsNullOrEmpty(_dte.Solution?.FullName)
                 ? String.Empty
-                : (stylerOptions.SearchToDrivesRoot ? Path.GetPathRoot(_dte.Solution.FullName) : Path.GetDirectoryName(_dte.Solution.FullName));
+                : (stylerOptions.SearchToDriveRoot ? Path.GetPathRoot(_dte.Solution.FullName) : Path.GetDirectoryName(_dte.Solution.FullName));
             var project = _dte.ActiveDocument?.ProjectItem?.ContainingProject;
 
             var configPath = GetConfigPathForItem(document.Path, solutionPath, project);

--- a/XamlStyler3.Package/StylerPackage.cs
+++ b/XamlStyler3.Package/StylerPackage.cs
@@ -151,7 +151,7 @@ namespace Xavalon.XamlStyler3.Package
 
             var solutionPath = String.IsNullOrEmpty(_dte.Solution?.FullName)
                 ? String.Empty
-                : Path.GetDirectoryName(_dte.Solution.FullName);
+                : (stylerOptions.SearchToDriveRoot ? Path.GetPathRoot(_dte.Solution.FullName) : Path.GetDirectoryName(_dte.Solution.FullName));
             var project = _dte.ActiveDocument?.ProjectItem?.ContainingProject;
 
             var configPath = GetConfigPathForItem(document.Path, solutionPath, project);

--- a/XamlStyler3.Package/XamlStyler3.Package.csproj
+++ b/XamlStyler3.Package/XamlStyler3.Package.csproj
@@ -122,9 +122,9 @@
       <VersionMajor>8</VersionMajor>
       <VersionMinor>0</VersionMinor>
       <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
+      <WrapperTool>tlbimp</WrapperTool>
       <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
     </COMReference>
     <COMReference Include="stdole">
       <Guid>{00020430-0000-0000-C000-000000000046}</Guid>

--- a/XamlStyler3.Package/source.extension.vsixmanifest
+++ b/XamlStyler3.Package/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="0c572937-0d4a-48cc-aa3f-875ffa9805ba" Version="3.1.1" Language="en-US" Publisher="Xavalon" />
+        <Identity Id="0c572937-0d4a-48cc-aa3f-875ffa9805ba" Version="3.1" Language="en-US" Publisher="Xavalon" />
         <DisplayName>XAML Styler</DisplayName>
         <Description xml:space="preserve">XAML Styler is a visual studio extension, which formats XAML source code by sorting the attributes based on their importance. This tool can help you/your team maintain a better XAML coding style as well as a much better XAML readability.</Description>
         <MoreInfo>https://github.com/Xavalon/XamlStyler/</MoreInfo>

--- a/XamlStyler3.Package/source.extension.vsixmanifest
+++ b/XamlStyler3.Package/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="0c572937-0d4a-48cc-aa3f-875ffa9805ba" Version="3.1" Language="en-US" Publisher="Xavalon" />
+        <Identity Id="0c572937-0d4a-48cc-aa3f-875ffa9805ba" Version="3.1.1" Language="en-US" Publisher="Xavalon" />
         <DisplayName>XAML Styler</DisplayName>
         <Description xml:space="preserve">XAML Styler is a visual studio extension, which formats XAML source code by sorting the attributes based on their importance. This tool can help you/your team maintain a better XAML coding style as well as a much better XAML readability.</Description>
         <MoreInfo>https://github.com/Xavalon/XamlStyler/</MoreInfo>


### PR DESCRIPTION
 When set to true, XAML Styler will look for an external XAML Styler configuration file not only up through your solution directory, but up through the drives root of the current solution so you can share one configuration file through multiple solutions. Default: true.