### PR TITLE
Load extension on open xaml

### DIFF
--- a/XamlStyler3.Package/ReleaseNotes.txt
+++ b/XamlStyler3.Package/ReleaseNotes.txt
@@ -3,6 +3,10 @@
 - VS2019 support
 - Package gets loaded dynamically when opening a XAML file
 
+3.1
+---
+
+
 3.0
 ---
 VS2017 release

--- a/XamlStyler3.Package/ReleaseNotes.txt
+++ b/XamlStyler3.Package/ReleaseNotes.txt
@@ -1,4 +1,9 @@
-﻿3.0
+﻿3.2
+----
+- VS2019 support
+- Package gets loaded dynamically when opening a XAML file
+
+3.0
 ---
 VS2017 release
 

--- a/XamlStyler3.Package/StylerPackage.cs
+++ b/XamlStyler3.Package/StylerPackage.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft;
 using Xavalon.XamlStyler.Core;
 using Xavalon.XamlStyler.Core.Options;
 using Xavalon.XamlStyler.Package;
@@ -48,8 +49,9 @@ namespace Xavalon.XamlStyler3.Package
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
             Trace.WriteLine(string.Format(CultureInfo.CurrentCulture, "Entering Initialize() of: {0}", ToString()));
             base.Initialize();
-            
+
             _dte = await GetServiceAsync(typeof(DTE)) as DTE;
+            Assumes.Present(_dte);
 
             if (_dte == null)
             {
@@ -57,6 +59,7 @@ namespace Xavalon.XamlStyler3.Package
             }
 
             _uiShell = await GetServiceAsync(typeof(IVsUIShell)) as IVsUIShell;
+            Assumes.Present(_uiShell);
 
             // Initialize command events listeners
             _events = _dte.Events;
@@ -84,6 +87,7 @@ namespace Xavalon.XamlStyler3.Package
 
         private bool IsFormatableDocument(Document document)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             var isFormatableDocument = !document.ReadOnly && document.Language == "XAML";
 
             if (!isFormatableDocument)
@@ -98,6 +102,7 @@ namespace Xavalon.XamlStyler3.Package
         private void OnFileSaveSelectedItemsBeforeExecute(string guid, int id, object customIn, object customOut,
                                                           ref bool cancelDefault)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             Document document = _dte.ActiveDocument;
 
             if (IsFormatableDocument(document))
@@ -116,7 +121,7 @@ namespace Xavalon.XamlStyler3.Package
         {
             // use parallel processing, but only on the documents that are formatable
             // (to avoid the overhead of Task creating when it's not necessary)
-
+            ThreadHelper.ThrowIfNotOnUIThread();
             List<Document> docs = new List<Document>();
             foreach (Document document in _dte.Documents)
             {
@@ -140,6 +145,7 @@ namespace Xavalon.XamlStyler3.Package
 
         private void Execute(Document document)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             if (!IsFormatableDocument(document))
             {
                 return;
@@ -164,8 +170,7 @@ namespace Xavalon.XamlStyler3.Package
 
             if (stylerOptions.UseVisualStudioIndentSize)
             {
-                int outIndentSize;
-                if (Int32.TryParse(xamlEditorProps.Item("IndentSize").Value.ToString(), out outIndentSize)
+                if (Int32.TryParse(xamlEditorProps.Item("IndentSize").Value.ToString(), out int outIndentSize)
                     && (outIndentSize > 0))
                 {
                     stylerOptions.IndentSize = outIndentSize;
@@ -250,6 +255,7 @@ namespace Xavalon.XamlStyler3.Package
         /// </summary>
         private void MenuItemCallback(object sender, EventArgs e)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             try
             {
                 _uiShell.SetWaitCursor();
@@ -263,7 +269,7 @@ namespace Xavalon.XamlStyler3.Package
             }
             catch (Exception ex)
             {
-                string title = string.Format("Error in {0}:", GetType().Name);
+                string title = $"Error in {GetType().Name}:";
                 string message = string.Format(
                     CultureInfo.CurrentCulture,
                     "{0}\r\n\r\nIf this deems a malfunctioning of styler, please kindly submit an issue at https://github.com/Xavalon/XamlStyler.",
@@ -275,6 +281,7 @@ namespace Xavalon.XamlStyler3.Package
 
         private void ShowMessageBox(string title, string message)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             Guid clsid = Guid.Empty;
             int result;
 

--- a/XamlStyler3.Package/StylerPackage.cs
+++ b/XamlStyler3.Package/StylerPackage.cs
@@ -45,10 +45,10 @@ namespace Xavalon.XamlStyler3.Package
 
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
             Trace.WriteLine(string.Format(CultureInfo.CurrentCulture, "Entering Initialize() of: {0}", ToString()));
             base.Initialize();
             
-            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
             _dte = await GetServiceAsync(typeof(DTE)) as DTE;
 
             if (_dte == null)

--- a/XamlStyler3.Package/XamlStyler3.Package.csproj
+++ b/XamlStyler3.Package/XamlStyler3.Package.csproj
@@ -57,7 +57,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="envdte100, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <EmbedInteropTypes>True</EmbedInteropTypes>
@@ -87,15 +87,11 @@
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop" />
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.12.0" />
-    <Reference Include="Microsoft.VisualStudio.Threading, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Threading.15.0.240\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
-    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=15.8.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Utilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.Utilities.15.0.26201\lib\net45\Microsoft.VisualStudio.Utilities.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Validation, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Validation.15.0.82\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
-    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Validation, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />

--- a/XamlStyler3.Package/XamlStyler3.Package.csproj
+++ b/XamlStyler3.Package/XamlStyler3.Package.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
-  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.15.0.25929-RC2\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.15.0.25929-RC2\build\Microsoft.VSSDK.BuildTools.props')" />
+  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.15.9.3032\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.15.9.3032\build\Microsoft.VSSDK.BuildTools.props')" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
@@ -56,7 +56,22 @@
     <DeployExtension>false</DeployExtension>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="envdte100, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="envdte80, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="envdte90, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.VisualStudio.Imaging, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Imaging.15.0.26201\lib\net45\Microsoft.VisualStudio.Imaging.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.OLE.Interop" />
     <Reference Include="Microsoft.VisualStudio.Shell.15.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.Shell.15.0.15.0.25901-RC\lib\Microsoft.VisualStudio.Shell.15.0.dll</HintPath>
@@ -72,6 +87,15 @@
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop" />
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.12.0" />
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Threading.15.0.240\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Utilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Utilities.15.0.26201\lib\net45\Microsoft.VisualStudio.Utilities.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Validation, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Validation.15.0.82\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
@@ -81,42 +105,6 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <COMReference Include="EnvDTE">
-      <Guid>{80CC9F66-E7D8-4DDD-85B6-D9E6CD0E93E2}</Guid>
-      <VersionMajor>8</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>tlbimp</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </COMReference>
-    <COMReference Include="EnvDTE100">
-      <Guid>{26AD1324-4B7C-44BC-84F8-B86AED45729F}</Guid>
-      <VersionMajor>10</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>tlbimp</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </COMReference>
-    <COMReference Include="EnvDTE80">
-      <Guid>{1A31287A-4D7D-413E-8E32-3B374931BD89}</Guid>
-      <VersionMajor>8</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>tlbimp</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </COMReference>
-    <COMReference Include="EnvDTE90">
-      <Guid>{2CE2370E-D744-4936-A090-3FFFE667B0E1}</Guid>
-      <VersionMajor>9</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>tlbimp</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </COMReference>
     <COMReference Include="Microsoft.VisualStudio.CommandBars">
       <Guid>{1CBA492E-7263-47BB-87FE-639000619B15}</Guid>
       <VersionMajor>8</VersionMajor>
@@ -205,19 +193,27 @@
       <Name>XamlStyler.Core</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.33\analyzers\cs\Microsoft.VisualStudio.SDK.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.122\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.dll" />
+  </ItemGroup>
   <PropertyGroup>
     <UseCodebase>true</UseCodebase>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.122\build\Microsoft.VisualStudio.Threading.Analyzers.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.122\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.15.0.25929-RC2\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.15.0.25929-RC2\build\Microsoft.VSSDK.BuildTools.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.15.0.25929-RC2\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.15.0.25929-RC2\build\Microsoft.VSSDK.BuildTools.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.122\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.122\build\Microsoft.VisualStudio.Threading.Analyzers.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.33\build\Microsoft.VisualStudio.SDK.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.33\build\Microsoft.VisualStudio.SDK.Analyzers.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.15.9.3032\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.15.9.3032\build\Microsoft.VSSDK.BuildTools.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.15.9.3032\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.15.9.3032\build\Microsoft.VSSDK.BuildTools.targets'))" />
   </Target>
-  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.15.0.25929-RC2\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.15.0.25929-RC2\build\Microsoft.VSSDK.BuildTools.targets')" />
+  <Import Project="..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.33\build\Microsoft.VisualStudio.SDK.Analyzers.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.33\build\Microsoft.VisualStudio.SDK.Analyzers.targets')" />
+  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.15.9.3032\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.15.9.3032\build\Microsoft.VSSDK.BuildTools.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/XamlStyler3.Package/XamlStyler3.Package.vsct
+++ b/XamlStyler3.Package/XamlStyler3.Package.vsct
@@ -39,6 +39,7 @@
  
   <VisibilityConstraints>
     <VisibilityItem context="XamlEditorCommandSetGuid" guid="CommandSetGuid" id="FormatXamlCommandId"/>
+    <VisibilityItem context="XamarinEditorCommandSetGuid" guid="CommandSetGuid" id="FormatXamlCommandId"/>
   </VisibilityConstraints>
   <!-- Keyboard Shortcuts -->
   <KeyBindings>

--- a/XamlStyler3.Package/XamlStyler3.Package.vsct
+++ b/XamlStyler3.Package/XamlStyler3.Package.vsct
@@ -22,6 +22,7 @@
       <Button guid="CommandSetGuid" id="FormatXamlCommandId" priority="0x0100" type="Button">
         <Parent guid="CommandSetGuid" id="MenuGroup" />
         <Icon guid="CommandIconGuid" id="CommandIcon1" />
+        <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
           <CommandName>FormatXamlCommandId</CommandName>
           <ButtonText>Format XAML</ButtonText>
@@ -36,6 +37,9 @@
     </Bitmaps>
   </Commands>
  
+  <VisibilityConstraints>
+    <VisibilityItem context="XamlEditorCommandSetGuid" guid="CommandSetGuid" id="FormatXamlCommandId"/>
+  </VisibilityConstraints>
   <!-- Keyboard Shortcuts -->
   <KeyBindings>
     <KeyBinding guid="CommandSetGuid" id="FormatXamlCommandId" editor="guidVSStd97" key1="K" mod1="Control" key2="2" mod2="Control" />

--- a/XamlStyler3.Package/packages.config
+++ b/XamlStyler3.Package/packages.config
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CompareNETObjects" version="3.05.0.0" targetFramework="net452" requireReinstallation="true" />
-  <package id="Microsoft.VisualStudio.Imaging" version="14.2.25123" targetFramework="net452" />
+  <package id="Microsoft.VisualStudio.Imaging" version="15.0.26201" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.OLE.Interop" version="7.10.6070" targetFramework="net452" />
+  <package id="Microsoft.VisualStudio.SDK.Analyzers" version="15.8.33" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Shell.14.0" version="14.2.25123" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Shell.15.0" version="15.0.25901-RC" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Shell.Framework" version="15.0.25901-RC" targetFramework="net452" />
@@ -18,8 +19,9 @@
   <package id="Microsoft.VisualStudio.Shell.Interop.9.0" version="9.0.30729" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.TextManager.Interop" version="7.10.6070" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.TextManager.Interop.8.0" version="8.0.50727" targetFramework="net452" />
-  <package id="Microsoft.VisualStudio.Threading" version="14.1.111" targetFramework="net452" />
-  <package id="Microsoft.VisualStudio.Utilities" version="14.2.25123" targetFramework="net452" />
-  <package id="Microsoft.VisualStudio.Validation" version="14.1.111" targetFramework="net452" />
-  <package id="Microsoft.VSSDK.BuildTools" version="15.0.25929-RC2" targetFramework="net452" developmentDependency="true" />
+  <package id="Microsoft.VisualStudio.Threading" version="15.0.240" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Threading.Analyzers" version="15.8.122" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Utilities" version="15.0.26201" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Validation" version="15.0.82" targetFramework="net461" />
+  <package id="Microsoft.VSSDK.BuildTools" version="15.9.3032" targetFramework="net461" developmentDependency="true" />
 </packages>

--- a/XamlStyler3.Package/source.extension.vsixmanifest
+++ b/XamlStyler3.Package/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="0c572937-0d4a-48cc-aa3f-875ffa9805ba" Version="3.1" Language="en-US" Publisher="Xavalon" />
+        <Identity Id="0c572937-0d4a-48cc-aa3f-875ffa9805ba" Version="3.2" Language="en-US" Publisher="Xavalon" />
         <DisplayName>XAML Styler</DisplayName>
         <Description xml:space="preserve">XAML Styler is a visual studio extension, which formats XAML source code by sorting the attributes based on their importance. This tool can help you/your team maintain a better XAML coding style as well as a much better XAML readability.</Description>
         <MoreInfo>https://github.com/Xavalon/XamlStyler/</MoreInfo>
@@ -13,18 +13,16 @@
         <Tags>XAML, add-in, WPF, Visual Studio, Extension, formatter, Silverlight, WP8, WinRT, Xamarin, UWP, Win10</Tags>
     </Metadata>
     <Installation AllUsers="true">
-        <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
-        <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
-        <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Community" />
+        <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
+        <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
+        <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Community" />
     </Installation>
     <Dependencies>
-
-        <Dependency Id="Microsoft.VisualStudio.MPF.15.0" DisplayName="Visual Studio MPF 15.0" d:Source="Installed" Version="[15.0]" />
     </Dependencies>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.25904.2,16.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.8.27729.1,17.0)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
With this the extension gets loaded only when a xaml file is opened the first time. saves time on solution load

also adds VS2019 support, bumps the version to 3.2

Closes #167 