### PR TITLE
Adding missing WPF inline elements InlineUIContainer and AnchoredBlock.

### DIFF
--- a/XamlStyler.Core/DocumentProcessors/ElementDocumentProcessor.cs
+++ b/XamlStyler.Core/DocumentProcessors/ElementDocumentProcessor.cs
@@ -23,8 +23,8 @@ namespace Xavalon.XamlStyler.Core.DocumentProcessors
         private readonly XmlEscapingService xmlEscapingService;
         private readonly IList<string> noNewLineElementsList;
         private readonly IList<string> firstLineAttributes;
-        private readonly string[] inlineCollections = { "TextBlock", "RichTextBlock", "Paragraph", "Span" };
-        private readonly string[] inlineTypes = { "Run", "Hyperlink", "Bold", "Italic", "Underline", "LineBreak", "Paragraph", "Span" };
+        private readonly string[] inlineCollections = { "TextBlock", "RichTextBlock", "Paragraph", "Run", "Span", "InlineUIContainer", "AnchoredBlock" };
+        private readonly string[] inlineTypes = { "Paragraph", "Run", "Span", "InlineUIContainer", "AnchoredBlock", "Hyperlink", "Bold", "Italic", "Underline", "LineBreak" };
 
         public ElementDocumentProcessor(
             IStylerOptions options,

--- a/XamlStyler.UnitTests/TestFiles/TestRunHandling.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestRunHandling.expected
@@ -68,6 +68,14 @@
       <TextBlock>
         <Span><Bold>Bold</Bold><Hyperlink>Hyperlink</Hyperlink><Italic>Italic</Italic><Run>Run</Run><Underline>Underline</Underline><LineBreak /><LineBreak /></Span>
       </TextBlock>
+      <!--  InlineUIContainer  -->
+      <TextBlock>
+        <InlineUIContainer><Bold>Bold</Bold><Hyperlink>Hyperlink</Hyperlink><Italic>Italic</Italic><Run>Run</Run><Underline>Underline</Underline><LineBreak /><LineBreak /></InlineUIContainer>
+      </TextBlock>
+      <!--  AnchoredBlock  -->
+      <TextBlock>
+        <AnchoredBlock><Bold>Bold</Bold><Hyperlink>Hyperlink</Hyperlink><Italic>Italic</Italic><Run>Run</Run><Underline>Underline</Underline><LineBreak /><LineBreak /></AnchoredBlock>
+      </TextBlock>
       <!--  RichTextBlock + Paragraph  -->
       <RichTextBlock>
         <Paragraph>

--- a/XamlStyler.UnitTests/TestFiles/TestRunHandling.testxaml
+++ b/XamlStyler.UnitTests/TestFiles/TestRunHandling.testxaml
@@ -59,6 +59,14 @@
   <TextBlock>
     <Span><Bold>Bold</Bold><Hyperlink>Hyperlink</Hyperlink><Italic>Italic</Italic><Run>Run</Run><Underline>Underline</Underline><LineBreak /><LineBreak /></Span>
   </TextBlock>
+  <!-- InlineUIContainer -->
+  <TextBlock>
+    <InlineUIContainer><Bold>Bold</Bold><Hyperlink>Hyperlink</Hyperlink><Italic>Italic</Italic><Run>Run</Run><Underline>Underline</Underline><LineBreak /><LineBreak /></InlineUIContainer>
+  </TextBlock>
+  <!-- AnchoredBlock -->
+  <TextBlock>
+    <AnchoredBlock><Bold>Bold</Bold><Hyperlink>Hyperlink</Hyperlink><Italic>Italic</Italic><Run>Run</Run><Underline>Underline</Underline><LineBreak /><LineBreak /></AnchoredBlock>
+  </TextBlock>
   <!-- RichTextBlock + Paragraph -->
   <RichTextBlock>
     <Paragraph>

--- a/XamlStyler.sln
+++ b/XamlStyler.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2024
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29306.81
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XamlStyler.Core", "XamlStyler.Core\XamlStyler.Core.csproj", "{BD2A5B6F-0B1C-4B1D-90AF-707F62BB12C0}"
 EndProject
@@ -17,16 +17,16 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{BD2A5B6F-0B1C-4B1D-90AF-707F62BB12C0}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{BD2A5B6F-0B1C-4B1D-90AF-707F62BB12C0}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{BD2A5B6F-0B1C-4B1D-90AF-707F62BB12C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BD2A5B6F-0B1C-4B1D-90AF-707F62BB12C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BD2A5B6F-0B1C-4B1D-90AF-707F62BB12C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BD2A5B6F-0B1C-4B1D-90AF-707F62BB12C0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E5245034-9CD0-4FC6-B141-BAE17BC251A5}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{E5245034-9CD0-4FC6-B141-BAE17BC251A5}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{E5245034-9CD0-4FC6-B141-BAE17BC251A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E5245034-9CD0-4FC6-B141-BAE17BC251A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E5245034-9CD0-4FC6-B141-BAE17BC251A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E5245034-9CD0-4FC6-B141-BAE17BC251A5}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5284FEA7-FC0B-45EA-8B16-9DA7F5E6D7B6}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{5284FEA7-FC0B-45EA-8B16-9DA7F5E6D7B6}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{5284FEA7-FC0B-45EA-8B16-9DA7F5E6D7B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5284FEA7-FC0B-45EA-8B16-9DA7F5E6D7B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5284FEA7-FC0B-45EA-8B16-9DA7F5E6D7B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5284FEA7-FC0B-45EA-8B16-9DA7F5E6D7B6}.Release|Any CPU.Build.0 = Release|Any CPU
 		{36E90337-BD31-49CF-89E9-7069CB5009C8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
Fixes #203.

This change also fixes some build configuration settings that were preventing debugging inside of the XamlStyler.Core project when testing extension in VS.