### PR TITLE
Fix #181: XML Processing instructions changed automatically

### DIFF
--- a/XamlStyler.Core/DocumentProcessors/ProcessInstructionDocumentProcessor.cs
+++ b/XamlStyler.Core/DocumentProcessors/ProcessInstructionDocumentProcessor.cs
@@ -29,13 +29,7 @@ namespace Xavalon.XamlStyler.Core.DocumentProcessors
                 output.Append(Environment.NewLine);
             }
 
-            output
-                .Append(currentIndentString)
-                .Append("<?")
-                .Append(xmlReader.Name)
-                .Append(" ")
-                .Append(xmlReader.Value)
-                .Append(" ?>");
+            output.Append($"{currentIndentString}<?{xmlReader.Name} {xmlReader.Value}?>");
         }
     }
 }

--- a/XamlStyler.Core/DocumentProcessors/ProcessInstructionDocumentProcessor.cs
+++ b/XamlStyler.Core/DocumentProcessors/ProcessInstructionDocumentProcessor.cs
@@ -29,7 +29,13 @@ namespace Xavalon.XamlStyler.Core.DocumentProcessors
                 output.Append(Environment.NewLine);
             }
 
-            output.Append(currentIndentString).Append("<?Mapping ").Append(xmlReader.Value).Append(" ?>");
+            output
+                .Append(currentIndentString)
+                .Append("<?")
+                .Append(xmlReader.Name)
+                .Append(" ")
+                .Append(xmlReader.Value)
+                .Append(" ?>");
         }
     }
 }

--- a/XamlStyler.UnitTests/FileHandlingIntegrationTests.cs
+++ b/XamlStyler.UnitTests/FileHandlingIntegrationTests.cs
@@ -295,6 +295,12 @@ namespace Xavalon.XamlStyler.UnitTests
         }
 
         [Test]
+        public void TestProcessingInstructionHandling()
+        {
+            this.DoTest(this.GetLegacyStylerOptions());
+        }
+
+        [Test]
         public void TestXmlnsAliasesHandling()
         {
             this.DoTest(this.GetLegacyStylerOptions());
@@ -459,7 +465,7 @@ namespace Xavalon.XamlStyler.UnitTests
             [System.Runtime.CompilerServices.CallerMemberName] string callerMemberName = "")
         {
             FileHandlingIntegrationTests.DoTest(
-                stylerOptions, 
+                stylerOptions,
                 Path.Combine("TestFiles", callerMemberName),
                 testIdentifier.ToString());
         }

--- a/XamlStyler.UnitTests/TestFiles/TestProcessingInstructionHandling.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestProcessingInstructionHandling.expected
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<?xaml-comp compile="true" ?>
+<?Mapping compile="true" ?>
+<ResourceDictionary xmlns="http://xamarin.com/schemas/2014/forms">
+  <ResourceDictionary.MergedDictionaries>
+    <ResourceDictionary Source="Colors.xaml" />
+    <ResourceDictionary Source="Fonts.xaml" />
+  </ResourceDictionary.MergedDictionaries>
+
+  <Style TargetType="{x:Type ui:PrimaryButton}">
+    <Setter Property="BackgroundColor" Value="{StaticResource Color__Primary_Button}" />
+    <Setter Property="TextColor" Value="{StaticResource Color__Primary_Button_Label}" />
+  </Style>
+
+  <Style TargetType="{x:Type ui:SecondaryButton}">
+    <Setter Property="BackgroundColor" Value="{StaticResource Color__Secondary_Button}" />
+    <Setter Property="TextColor" Value="{StaticResource Color__Secondary_Button_Label}" />
+  </Style>
+
+  <Style TargetType="{x:Type ui:IconToggleButton}">
+    <Setter Property="TextColor" Value="{StaticResource Color__Secondary_Button_Label}" />
+    <Setter Property="HorizontalTextAlignment" Value="Center" />
+    <Setter Property="VerticalTextAlignment" Value="Center" />
+  </Style>
+
+</ResourceDictionary>

--- a/XamlStyler.UnitTests/TestFiles/TestProcessingInstructionHandling.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestProcessingInstructionHandling.expected
@@ -1,26 +1,4 @@
 ﻿<?xml version="1.0" encoding="UTF-8" ?>
-<?xaml-comp compile="true" ?>
-<?Mapping compile="true" ?>
-<ResourceDictionary xmlns="http://xamarin.com/schemas/2014/forms">
-  <ResourceDictionary.MergedDictionaries>
-    <ResourceDictionary Source="Colors.xaml" />
-    <ResourceDictionary Source="Fonts.xaml" />
-  </ResourceDictionary.MergedDictionaries>
-
-  <Style TargetType="{x:Type ui:PrimaryButton}">
-    <Setter Property="BackgroundColor" Value="{StaticResource Color__Primary_Button}" />
-    <Setter Property="TextColor" Value="{StaticResource Color__Primary_Button_Label}" />
-  </Style>
-
-  <Style TargetType="{x:Type ui:SecondaryButton}">
-    <Setter Property="BackgroundColor" Value="{StaticResource Color__Secondary_Button}" />
-    <Setter Property="TextColor" Value="{StaticResource Color__Secondary_Button_Label}" />
-  </Style>
-
-  <Style TargetType="{x:Type ui:IconToggleButton}">
-    <Setter Property="TextColor" Value="{StaticResource Color__Secondary_Button_Label}" />
-    <Setter Property="HorizontalTextAlignment" Value="Center" />
-    <Setter Property="VerticalTextAlignment" Value="Center" />
-  </Style>
-
-</ResourceDictionary>
+<?xaml-comp compile="true"?>
+<?Mapping compile="true"?>
+<XmlRoot />

--- a/XamlStyler.UnitTests/TestFiles/TestProcessingInstructionHandling.testxaml
+++ b/XamlStyler.UnitTests/TestFiles/TestProcessingInstructionHandling.testxaml
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<?xaml-comp compile="true"?>
+<?Mapping compile="true"?>
+<ResourceDictionary xmlns="http://xamarin.com/schemas/2014/forms">
+  <ResourceDictionary.MergedDictionaries>
+    <ResourceDictionary Source="Colors.xaml" />
+    <ResourceDictionary Source="Fonts.xaml" />
+  </ResourceDictionary.MergedDictionaries>
+
+  <Style TargetType="{x:Type ui:PrimaryButton}">
+    <Setter Property="BackgroundColor" Value="{StaticResource Color__Primary_Button}" />
+    <Setter Property="TextColor" Value="{StaticResource Color__Primary_Button_Label}" />
+  </Style>
+
+  <Style TargetType="{x:Type ui:SecondaryButton}">
+    <Setter Property="BackgroundColor" Value="{StaticResource Color__Secondary_Button}" />
+    <Setter Property="TextColor" Value="{StaticResource Color__Secondary_Button_Label}" />
+  </Style>
+
+  <Style TargetType="{x:Type ui:IconToggleButton}">
+    <Setter Property="TextColor" Value="{StaticResource Color__Secondary_Button_Label}" />
+    <Setter Property="HorizontalTextAlignment" Value="Center" />
+    <Setter Property="VerticalTextAlignment" Value="Center" />
+  </Style>
+
+</ResourceDictionary>

--- a/XamlStyler.UnitTests/TestFiles/TestProcessingInstructionHandling.testxaml
+++ b/XamlStyler.UnitTests/TestFiles/TestProcessingInstructionHandling.testxaml
@@ -1,26 +1,4 @@
 ﻿<?xml version="1.0" encoding="UTF-8" ?>
 <?xaml-comp compile="true"?>
 <?Mapping compile="true"?>
-<ResourceDictionary xmlns="http://xamarin.com/schemas/2014/forms">
-  <ResourceDictionary.MergedDictionaries>
-    <ResourceDictionary Source="Colors.xaml" />
-    <ResourceDictionary Source="Fonts.xaml" />
-  </ResourceDictionary.MergedDictionaries>
-
-  <Style TargetType="{x:Type ui:PrimaryButton}">
-    <Setter Property="BackgroundColor" Value="{StaticResource Color__Primary_Button}" />
-    <Setter Property="TextColor" Value="{StaticResource Color__Primary_Button_Label}" />
-  </Style>
-
-  <Style TargetType="{x:Type ui:SecondaryButton}">
-    <Setter Property="BackgroundColor" Value="{StaticResource Color__Secondary_Button}" />
-    <Setter Property="TextColor" Value="{StaticResource Color__Secondary_Button_Label}" />
-  </Style>
-
-  <Style TargetType="{x:Type ui:IconToggleButton}">
-    <Setter Property="TextColor" Value="{StaticResource Color__Secondary_Button_Label}" />
-    <Setter Property="HorizontalTextAlignment" Value="Center" />
-    <Setter Property="VerticalTextAlignment" Value="Center" />
-  </Style>
-
-</ResourceDictionary>
+<XmlRoot />

--- a/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
+++ b/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
@@ -92,6 +92,12 @@
     <None Include="TestFiles\TestAttributeIndentationHandling_0.expected">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="TestFiles\TestProcessingInstructionHandling.expected">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestFiles\TestProcessingInstructionHandling.testxaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="TestFiles\TestSingleLineNestedMarkupExtensions.expected">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Hello everyone :-)

well, I honestly did not spent my Easter holidays heading into this bug (as I announced in the Issue #181 ) but here is my very first idea of fixing the processing-instruction (PI) problem as described.

Personal disclaimer:

I am not an X(a)ML-guru and I honestly did not understand the need of statically converting every XML-PI into `<?Mapping ...` - but, as you can read from the test file, it's going to fix the bug described without breaking any other PI.

If there is any need of transforming other PIs into `Mapping` feel free to tell me what should be transformed into Mapping or give me some more help getting more knowledge about this Mapping-PI ;-)
