### PR TITLE
fix "Save All" parallel execution

### DIFF
--- a/XamlStyler.Package/StylerPackage.cs
+++ b/XamlStyler.Package/StylerPackage.cs
@@ -201,43 +201,34 @@ namespace Xavalon.XamlStyler.Package
 
         private string GetConfigPathForItem(string path, string solutionRoot, Project project)
         {
-            try
+            if (String.IsNullOrWhiteSpace(path))
             {
-                if (String.IsNullOrWhiteSpace(path))
-                {
-                    return null;
-                }
-
-                var projectFullName = project?.FullName;
-                var projectDirectory = String.IsNullOrEmpty(projectFullName)
-                    ? String.Empty
-                    : Path.GetDirectoryName(projectFullName);
-
-                IEnumerable<string> configPaths
-                    = (path.StartsWith(solutionRoot, StringComparison.InvariantCultureIgnoreCase))
-                        ? StylerPackage.GetConfigPathBetweenPaths(path, solutionRoot)
-                        : StylerPackage.GetConfigPathBetweenPaths(path, projectDirectory);
-
-                // find the FullPath of "Settings.XamlStyler" ref in project
-                var filePathsInProject = project?.ProjectItems.Cast<ProjectItem>()
-                    .Where(x => string.Equals(x.Name, "Settings.XamlStyler"))
-                    .SelectMany(x => x.Properties.Cast<Property>())
-                    .Where(x => string.Equals(x.Name, "FullPath"))
-                    .Select(x => x.Value as string);
-
-                if (filePathsInProject != null)
-                {
-                    configPaths = configPaths.Concat(filePathsInProject);
-                }
-
-                return configPaths.FirstOrDefault(File.Exists);
-            }
-            catch
-            {
-                // Fail gracefully.
+                return null;
             }
 
-            return null;
+            var projectFullName = project?.FullName;
+            var projectDirectory = String.IsNullOrEmpty(projectFullName)
+                ? String.Empty
+                : Path.GetDirectoryName(projectFullName);
+
+            IEnumerable<string> configPaths
+                = (path.StartsWith(solutionRoot, StringComparison.InvariantCultureIgnoreCase))
+                    ? StylerPackage.GetConfigPathBetweenPaths(path, solutionRoot)
+                    : StylerPackage.GetConfigPathBetweenPaths(path, projectDirectory);
+
+            // find the FullPath of "Settings.XamlStyler" ref in project
+            var filePathsInProject = project?.ProjectItems.Cast<ProjectItem>()
+                .Where(x => { ThreadHelper.ThrowIfNotOnUIThread(); return string.Equals(x.Name, "Settings.XamlStyler"); })
+                .SelectMany(x => { ThreadHelper.ThrowIfNotOnUIThread(); return x.Properties.Cast<Property>(); })
+                .Where(x => { ThreadHelper.ThrowIfNotOnUIThread(); return string.Equals(x.Name, "FullPath"); })
+                .Select(x => { ThreadHelper.ThrowIfNotOnUIThread(); return x.Value as string; });
+
+            if (filePathsInProject != null)
+            {
+                configPaths = configPaths.Concat(filePathsInProject);
+            }
+
+            return configPaths.FirstOrDefault(File.Exists);
         }
 
         // Searches for configuration file up through solution root directory.

--- a/XamlStyler.Package/StylerPackage.cs
+++ b/XamlStyler.Package/StylerPackage.cs
@@ -125,6 +125,12 @@ namespace Xavalon.XamlStyler.Package
             List<Document> docs = new List<Document>();
             foreach (Document document in _dte.Documents)
             {
+                // exclude unopened document.
+                if (document.ActiveWindow == null)
+                {
+                    continue;
+                }
+
                 if (IsFormatableDocument(document))
                 {
                     docs.Add(document);

--- a/XamlStyler.Package/StylerPackage.cs
+++ b/XamlStyler.Package/StylerPackage.cs
@@ -119,10 +119,16 @@ namespace Xavalon.XamlStyler.Package
         private void OnFileSaveAllBeforeExecute(string guid, int id, object customIn, object customOut,
                                                 ref bool cancelDefault)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            var globalOptions = GetDialogPage(typeof(PackageOptions)).AutomationObject as IStylerOptions;
+            if (!globalOptions.BeautifyOnSave)
+            {
+                return;
+            }
+
             // use parallel processing, but only on the documents that are formatable
             // (to avoid the overhead of Task creating when it's not necessary)
-            ThreadHelper.ThrowIfNotOnUIThread();
-            List<Document> docs = new List<Document>();
+            var jobs = new List<Func<Action>>();
             foreach (Document document in _dte.Documents)
             {
                 // exclude unopened document.
@@ -133,30 +139,29 @@ namespace Xavalon.XamlStyler.Package
 
                 if (IsFormatableDocument(document))
                 {
-                    docs.Add(document);
+                    jobs.Add(SetupExecuteContinuation(document));
                 }
             }
 
-            Parallel.ForEach(docs, document =>
+            // executes job() in parallel, then execute finish() sequentially
+            foreach (var finish in jobs.AsParallel().Select(job => job()))
             {
-                var options = GetDialogPage(typeof(PackageOptions)).AutomationObject as IStylerOptions;
-
-                if (options.BeautifyOnSave)
-                {
-                    Execute(document);
-                }
+                finish();
             }
-                );
         }
 
         private void Execute(Document document)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            if (!IsFormatableDocument(document))
+            if (IsFormatableDocument(document))
             {
-                return;
+                SetupExecuteContinuation(document)()();
             }
+        }
 
+        private Func<Action> SetupExecuteContinuation(Document document)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
             Properties xamlEditorProps = _dte.Properties["TextEditor", "XAML"];
 
             var stylerOptions = GetDialogPage(typeof(PackageOptions)).AutomationObject as IStylerOptions;
@@ -185,18 +190,27 @@ namespace Xavalon.XamlStyler.Package
 
             stylerOptions.IndentWithTabs = (bool)xamlEditorProps.Item("InsertTabs").Value;
 
-            StylerService styler = new StylerService(stylerOptions);
-
             var textDocument = (TextDocument)document.Object("TextDocument");
-            
+
             EditPoint startPoint = textDocument.StartPoint.CreateEditPoint();
             EditPoint endPoint = textDocument.EndPoint.CreateEditPoint();
 
             string xamlSource = startPoint.GetText(endPoint);
-            xamlSource = styler.StyleDocument(xamlSource);
 
-            const int vsEPReplaceTextKeepMarkers = 1;
-            startPoint.ReplaceText(endPoint, xamlSource, vsEPReplaceTextKeepMarkers);
+            return () =>
+            {
+                // this part can be executed in parallel.
+                StylerService styler = new StylerService(stylerOptions);
+                xamlSource = styler.StyleDocument(xamlSource);
+
+                return () =>
+                {
+                    // this part should be executed sequentially.
+                    ThreadHelper.ThrowIfNotOnUIThread();
+                    const int vsEPReplaceTextKeepMarkers = 1;
+                    startPoint.ReplaceText(endPoint, xamlSource, vsEPReplaceTextKeepMarkers);
+                };
+            };
         }
 
         private string GetConfigPathForItem(string path, string solutionRoot, Project project)


### PR DESCRIPTION
This PR includes:

* fixes "Save All" parallel execution by separating synchronous method.
* "Save All" applied only for opened documents.
@peterM suggests this fix in #142.

related #142 #216 