### PR TITLE
Remove whitespace at the end of the XML declaration node

### DIFF
--- a/XamlStyler.Core/DocumentProcessors/XmlDeclarationDocumentProcessor.cs
+++ b/XamlStyler.Core/DocumentProcessors/XmlDeclarationDocumentProcessor.cs
@@ -9,9 +9,7 @@ namespace Xavalon.XamlStyler.Core.DocumentProcessors
     {
         public void Process(XmlReader xmlReader, StringBuilder output, ElementProcessContext elementProcessContext)
         {
-            output.Append("<?xml ");
-            output.Append(xmlReader.Value.Trim());
-            output.Append(" ?>");
+            output.Append($"<?xml {xmlReader.Value.Trim()}?>");
         }
     }
 }

--- a/XamlStyler.UnitTests/FileHandlingIntegrationTests.cs
+++ b/XamlStyler.UnitTests/FileHandlingIntegrationTests.cs
@@ -258,6 +258,12 @@ namespace Xavalon.XamlStyler.UnitTests
         }
 
         [Test]
+        public void TestXmlDeclarationHandling()
+        {
+            this.DoTest(this.GetLegacyStylerOptions());
+        }
+
+        [Test]
         public void TestNestedPropertiesAndChildrenHandling()
         {
             var stylerOptions = new StylerOptions(
@@ -459,7 +465,7 @@ namespace Xavalon.XamlStyler.UnitTests
             [System.Runtime.CompilerServices.CallerMemberName] string callerMemberName = "")
         {
             FileHandlingIntegrationTests.DoTest(
-                stylerOptions, 
+                stylerOptions,
                 Path.Combine("TestFiles", callerMemberName),
                 testIdentifier.ToString());
         }

--- a/XamlStyler.UnitTests/TestFiles/TestXmlDeclarationHandling.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestXmlDeclarationHandling.expected
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<Root />

--- a/XamlStyler.UnitTests/TestFiles/TestXmlDeclarationHandling.testxaml
+++ b/XamlStyler.UnitTests/TestFiles/TestXmlDeclarationHandling.testxaml
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<Root />

--- a/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
+++ b/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
@@ -194,6 +194,12 @@
     <None Include="TestFiles\TestDesignReferenceRemoval.testxaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="TestFiles\TestXmlDeclarationHandling.expected">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestFiles\TestXmlDeclarationHandling.testxaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="TestFiles\TestWildcard.expected">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
A suggestion based on the output results from PR #215 

This would change a lot of files for the current users, but make things consistent across the similar node formats.

On the other hand it could be better to ignore this and add the whitespace to the Processing Instructions again not causing changes in _every_ XAML-file for every user?

Cheers :-)