### PR TITLE
Downgrade Newtonsoft.Json to v9.0.1

### DIFF
--- a/XamlStyler.Core/XamlStyler.Core.csproj
+++ b/XamlStyler.Core/XamlStyler.Core.csproj
@@ -7,9 +7,6 @@
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
     <Copyright>Copyright © Xavalon 2019</Copyright>
-    <ApplicationIcon />
-    <OutputType>Library</OutputType>
-    <StartupObject />
   </PropertyGroup>
 
   <ItemGroup>

--- a/XamlStyler.Core/XamlStyler.Core.csproj
+++ b/XamlStyler.Core/XamlStyler.Core.csproj
@@ -7,6 +7,9 @@
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
     <Copyright>Copyright © Xavalon 2019</Copyright>
+    <ApplicationIcon />
+    <OutputType>Library</OutputType>
+    <StartupObject />
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,7 +24,7 @@
       <Version>1.1.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.3</Version>
+      <Version>9.0.1</Version>
     </PackageReference>
   </ItemGroup>
 <ItemGroup>


### PR DESCRIPTION
Fixes #242 

This will fix compatibility with Visual Studio 2017 versions 15.3 and higher.

We were a bit too ambitious in updating Newtonsoft.Json in #217. We had been on 8.0.3, but this version is not compatible with .NET Standard/Core. However, 12.0.3 is not compatible with Visual Studio 15.0 VSIX packages. Visual Studio [15.3](https://docs.microsoft.com/en-us/visualstudio/releasenotes/vs2017-relnotes-v15.3) added better support for .NET Core development, including bumping up support of Newtonsoft.Json to [9.0.1](https://github.com/JamesNK/Newtonsoft.Json/releases/tag/9.0.1), which added support for .NET Core.

More information here: [Using Newtonsoft.Json in a Visual Studio extension](https://devblogs.microsoft.com/visualstudio/using-newtonsoft-json-in-a-visual-studio-extension/)