### PR TITLE
Migrate from legacy analysis (FxCop) to source analysis (FxCop analyzers)

### DIFF
--- a/XamlStyler.Console/Options.cs
+++ b/XamlStyler.Console/Options.cs
@@ -8,10 +8,10 @@ using Xavalon.XamlStyler.Core.Options;
 namespace Xavalon.XamlStyler.Xmagic
 {
     // CLI-intrinsic options
-    public sealed partial class Options
+    public sealed partial class CommandLineOptions
     {
         [Option('f', "file", Separator = ',', HelpText = "XAML file to process (supports comma-separated list).")]
-        public IList<string> File { get; set; }
+        public IList<string> File { get; private set; }
 
         [Option('d', "directory", HelpText = "Directory to process XAML files in.")]
         public string Directory { get; set; }
@@ -31,7 +31,7 @@ namespace Xavalon.XamlStyler.Xmagic
     }
 
     // Styler overrides
-    public sealed partial class Options
+    public sealed partial class CommandLineOptions
     {
         [Option("indent-size", HelpText = "Override: indent size.")]
         public int? IndentSize { get; set; }

--- a/XamlStyler.Console/Program.cs
+++ b/XamlStyler.Console/Program.cs
@@ -18,7 +18,7 @@ namespace Xavalon.XamlStyler.Xmagic
         {
             var writer = new StringWriter();
             var parser = new Parser(_ => _.HelpWriter = writer);
-            var result = parser.ParseArguments<Options>(args);
+            var result = parser.ParseArguments<CommandLineOptions>(args);
 
             result.WithNotParsed(_ =>
             {
@@ -56,10 +56,10 @@ namespace Xavalon.XamlStyler.Xmagic
 
     public sealed class XamlStylerConsole
     {
-        private readonly Options options;
+        private readonly CommandLineOptions options;
         private readonly StylerService stylerService;
 
-        public XamlStylerConsole(Options options)
+        public XamlStylerConsole(CommandLineOptions options)
         {
             this.options = options;
 
@@ -211,7 +211,7 @@ namespace Xavalon.XamlStyler.Xmagic
         }
     }
 
-    public sealed class Options
+    public sealed class CommandLineOptions
     {
         [Option('f', "file", Separator = ',', HelpText = "XAML file to process (supports comma-separated list).")]
         public IList<string> File { get; set; }

--- a/XamlStyler.Console/Program.cs
+++ b/XamlStyler.Console/Program.cs
@@ -12,7 +12,7 @@ namespace Xavalon.XamlStyler.Xmagic
         {
             var writer = new StringWriter();
             var parser = new Parser(_ => _.HelpWriter = writer);
-            var result = parser.ParseArguments<Options>(args);
+            var result = parser.ParseArguments<CommandLineOptions>(args);
 
             result.WithNotParsed(_ =>
             {

--- a/XamlStyler.Console/Program.cs
+++ b/XamlStyler.Console/Program.cs
@@ -14,163 +14,6 @@ namespace Xavalon.XamlStyler.Xmagic
 {
     public sealed class Program
     {
-        public sealed class XamlStylerConsole
-        {
-            private readonly Options options;
-            private readonly StylerService stylerService;
-
-            public XamlStylerConsole(Options options)
-            {
-                this.options = options;
-
-                IStylerOptions stylerOptions = new StylerOptions();
-
-                if (this.options.Configuration != null)
-                {
-                    stylerOptions = this.LoadConfiguration(this.options.Configuration);
-                }
-
-                this.stylerService = new StylerService(stylerOptions);
-            }
-
-            public void Process(ProcessType processType)
-            {
-                int successCount = 0;
-
-                IList<string> files;
-
-                switch(processType)
-                {
-                    case ProcessType.File:
-                        files = this.options.File;
-                        break;
-                    case ProcessType.Directory:
-                        var searchOption = this.options.IsRecursive
-                            ? SearchOption.AllDirectories
-                            : SearchOption.TopDirectoryOnly;
-                        files = (File.GetAttributes(this.options.Directory).HasFlag(FileAttributes.Directory))
-                            ? Directory.GetFiles(this.options.Directory, "*.xaml", searchOption).ToList()
-                            : new List<string>();
-                        break;
-                    default:
-                        throw new ArgumentException("Invalid ProcessType");
-                }
-
-                foreach (string file in files)
-                {
-                    if (this.TryProcessFile(file))
-                    {
-                        successCount++;
-                    }
-                }
-
-                this.Log($"Processed {successCount} of {files.Count} files.", LogLevel.Minimal);
-            }
-
-            private bool TryProcessFile(string file)
-            {
-                this.Log($"Processing: {file}");
-
-                if (!options.Ignore)
-                {
-                    var extension = Path.GetExtension(file);
-                    this.Log($"Extension: {extension}", LogLevel.Debug);
-
-                    if (!extension.Equals(".xaml", StringComparison.OrdinalIgnoreCase))
-                    {
-                        this.Log("Skipping... Can only process XAML files. Use the --ignore parameter to override.");
-                        return false;
-                    }
-                }
-
-                var path = Path.GetFullPath(file);
-                this.Log($"Full Path: {file}", LogLevel.Debug);
-
-                // If the options already has a configuration file set, we don't need to go hunting for one
-                string configurationPath = string.IsNullOrEmpty(this.options.Configuration) ? this.GetConfigurationFromPath(path) : null;
-
-                string originalContent = null;
-                Encoding encoding = Encoding.UTF8; // Visual Studio by default uses UTF8
-                using (var reader = new StreamReader(path))
-                {
-                    originalContent = reader.ReadToEnd();
-                    encoding = reader.CurrentEncoding;
-                    this.Log($"\nOriginal Content:\n\n{originalContent}\n", LogLevel.Insanity);
-                }
-
-                var formattedOutput = String.IsNullOrWhiteSpace(configurationPath)
-                    ? stylerService.StyleDocument(originalContent)
-                    : new StylerService(this.LoadConfiguration(configurationPath)).StyleDocument(originalContent);
-
-                this.Log($"\nFormatted Output:\n\n{formattedOutput}\n", LogLevel.Insanity);
-
-                using (var writer = new StreamWriter(path, false, encoding))
-                {
-                    try
-                    {
-                        writer.Write(formattedOutput);
-                        this.Log($"Finished Processing: {file}", LogLevel.Verbose);
-                    }
-                    catch (Exception e)
-                    {
-                        this.Log("Skipping... Error formatting XAML. Increase log level for more details.");
-                        this.Log($"Exception: {e.Message}", LogLevel.Verbose);
-                        this.Log($"StackTrace: {e.StackTrace}", LogLevel.Debug);
-                    }
-                }
-
-                return true;
-            }
-
-            private IStylerOptions LoadConfiguration(string path)
-            {
-                StylerOptions stylerOptions = new StylerOptions(path);
-                this.Log(JsonConvert.SerializeObject(stylerOptions), LogLevel.Insanity);
-                this.Log(JsonConvert.SerializeObject(stylerOptions.AttributeOrderingRuleGroups), LogLevel.Debug);
-                return stylerOptions;
-            }
-
-            private string GetConfigurationFromPath(string path)
-            {
-                try
-                {
-                    if (String.IsNullOrWhiteSpace(path))
-                    {
-                        return null;
-                    }
-
-                    bool isSolutionRoot = false;
-
-                    while (!isSolutionRoot && ((path = Path.GetDirectoryName(path)) != null))
-                    {
-                        isSolutionRoot = Directory.Exists(Path.Combine(path, ".vs"));
-                        this.Log($"In solution root: {isSolutionRoot}", LogLevel.Debug);
-                        var configFile = Path.Combine(path, "Settings.XamlStyler");
-                        this.Log($"Looking in: {path}", LogLevel.Debug);
-
-                        if (File.Exists(configFile))
-                        {
-                            this.Log($"Configuration Found: {configFile}", LogLevel.Verbose);
-                            return configFile;
-                        }
-                    }
-                }
-                catch
-                {
-                }
-
-                return null;
-            }
-
-            private void Log(string value, LogLevel logLevel = LogLevel.Default)
-            {
-                if (logLevel <= this.options.LogLevel)
-                {
-                    Console.WriteLine(value);
-                }
-            }
-        }
-
         public static void Main(string[] args)
         {
             var writer = new StringWriter();
@@ -209,42 +52,199 @@ namespace Xavalon.XamlStyler.Xmagic
                 }
             });
         }
+    }
 
-        public sealed class Options
+    public sealed class XamlStylerConsole
+    {
+        private readonly Options options;
+        private readonly StylerService stylerService;
+
+        public XamlStylerConsole(Options options)
         {
-            [Option('f', "file", Separator = ',', HelpText = "XAML file to process (supports comma-separated list).")]
-            public IList<string> File { get; set; }
+            this.options = options;
 
-            [Option('d', "directory", HelpText = "Directory to process XAML files in.")]
-            public string Directory { get; set; }
+            IStylerOptions stylerOptions = new StylerOptions();
 
-            [Option('c', "config", HelpText = "JSON file containing XAML Styler settings configuration.")]
-            public string Configuration { get; set; }
+            if (this.options.Configuration != null)
+            {
+                stylerOptions = this.LoadConfiguration(this.options.Configuration);
+            }
 
-            [Option('i', "ignore", Default = false, HelpText = "Ignore XAML file type check and process all files.")]
-            public bool Ignore { get; set; }
-
-            [Option('r', "recursive", Default = false, HelpText = "Recursively process specified directory.")]
-            public bool IsRecursive { get; set; }
-
-            [Option('l', "loglevel", Default = LogLevel.Default, HelpText = "Levels in order of increasing detail: None, Minimal, Default, Verbose, Debug")]
-            public LogLevel LogLevel { get; set; }
+            this.stylerService = new StylerService(stylerOptions);
         }
 
-        public enum LogLevel
+        public void Process(ProcessType processType)
         {
-            None = 0,
-            Minimal = 1,
-            Default = 2,
-            Verbose = 3,
-            Debug = 4,
-            Insanity = 5,
+            int successCount = 0;
+
+            IList<string> files;
+
+            switch (processType)
+            {
+                case ProcessType.File:
+                    files = this.options.File;
+                    break;
+                case ProcessType.Directory:
+                    var searchOption = this.options.IsRecursive
+                        ? SearchOption.AllDirectories
+                        : SearchOption.TopDirectoryOnly;
+                    files = (File.GetAttributes(this.options.Directory).HasFlag(FileAttributes.Directory))
+                        ? Directory.GetFiles(this.options.Directory, "*.xaml", searchOption).ToList()
+                        : new List<string>();
+                    break;
+                default:
+                    throw new ArgumentException("Invalid ProcessType");
+            }
+
+            foreach (string file in files)
+            {
+                if (this.TryProcessFile(file))
+                {
+                    successCount++;
+                }
+            }
+
+            this.Log($"Processed {successCount} of {files.Count} files.", LogLevel.Minimal);
         }
 
-        public enum ProcessType
+        private bool TryProcessFile(string file)
         {
-            File,
-            Directory,
+            this.Log($"Processing: {file}");
+
+            if (!options.Ignore)
+            {
+                var extension = Path.GetExtension(file);
+                this.Log($"Extension: {extension}", LogLevel.Debug);
+
+                if (!extension.Equals(".xaml", StringComparison.OrdinalIgnoreCase))
+                {
+                    this.Log("Skipping... Can only process XAML files. Use the --ignore parameter to override.");
+                    return false;
+                }
+            }
+
+            var path = Path.GetFullPath(file);
+            this.Log($"Full Path: {file}", LogLevel.Debug);
+
+            // If the options already has a configuration file set, we don't need to go hunting for one
+            string configurationPath = string.IsNullOrEmpty(this.options.Configuration) ? this.GetConfigurationFromPath(path) : null;
+
+            string originalContent = null;
+            Encoding encoding = Encoding.UTF8; // Visual Studio by default uses UTF8
+            using (var reader = new StreamReader(path))
+            {
+                originalContent = reader.ReadToEnd();
+                encoding = reader.CurrentEncoding;
+                this.Log($"\nOriginal Content:\n\n{originalContent}\n", LogLevel.Insanity);
+            }
+
+            var formattedOutput = String.IsNullOrWhiteSpace(configurationPath)
+                ? stylerService.StyleDocument(originalContent)
+                : new StylerService(this.LoadConfiguration(configurationPath)).StyleDocument(originalContent);
+
+            this.Log($"\nFormatted Output:\n\n{formattedOutput}\n", LogLevel.Insanity);
+
+            using (var writer = new StreamWriter(path, false, encoding))
+            {
+                try
+                {
+                    writer.Write(formattedOutput);
+                    this.Log($"Finished Processing: {file}", LogLevel.Verbose);
+                }
+                catch (Exception e)
+                {
+                    this.Log("Skipping... Error formatting XAML. Increase log level for more details.");
+                    this.Log($"Exception: {e.Message}", LogLevel.Verbose);
+                    this.Log($"StackTrace: {e.StackTrace}", LogLevel.Debug);
+                }
+            }
+
+            return true;
         }
+
+        private IStylerOptions LoadConfiguration(string path)
+        {
+            StylerOptions stylerOptions = new StylerOptions(path);
+            this.Log(JsonConvert.SerializeObject(stylerOptions), LogLevel.Insanity);
+            this.Log(JsonConvert.SerializeObject(stylerOptions.AttributeOrderingRuleGroups), LogLevel.Debug);
+            return stylerOptions;
+        }
+
+        private string GetConfigurationFromPath(string path)
+        {
+            try
+            {
+                if (String.IsNullOrWhiteSpace(path))
+                {
+                    return null;
+                }
+
+                bool isSolutionRoot = false;
+
+                while (!isSolutionRoot && ((path = Path.GetDirectoryName(path)) != null))
+                {
+                    isSolutionRoot = Directory.Exists(Path.Combine(path, ".vs"));
+                    this.Log($"In solution root: {isSolutionRoot}", LogLevel.Debug);
+                    var configFile = Path.Combine(path, "Settings.XamlStyler");
+                    this.Log($"Looking in: {path}", LogLevel.Debug);
+
+                    if (File.Exists(configFile))
+                    {
+                        this.Log($"Configuration Found: {configFile}", LogLevel.Verbose);
+                        return configFile;
+                    }
+                }
+            }
+            catch
+            {
+            }
+
+            return null;
+        }
+
+        private void Log(string value, LogLevel logLevel = LogLevel.Default)
+        {
+            if (logLevel <= this.options.LogLevel)
+            {
+                Console.WriteLine(value);
+            }
+        }
+    }
+
+    public sealed class Options
+    {
+        [Option('f', "file", Separator = ',', HelpText = "XAML file to process (supports comma-separated list).")]
+        public IList<string> File { get; set; }
+
+        [Option('d', "directory", HelpText = "Directory to process XAML files in.")]
+        public string Directory { get; set; }
+
+        [Option('c', "config", HelpText = "JSON file containing XAML Styler settings configuration.")]
+        public string Configuration { get; set; }
+
+        [Option('i', "ignore", Default = false, HelpText = "Ignore XAML file type check and process all files.")]
+        public bool Ignore { get; set; }
+
+        [Option('r', "recursive", Default = false, HelpText = "Recursively process specified directory.")]
+        public bool IsRecursive { get; set; }
+
+        [Option('l', "loglevel", Default = LogLevel.Default, HelpText = "Levels in order of increasing detail: None, Minimal, Default, Verbose, Debug")]
+        public LogLevel LogLevel { get; set; }
+    }
+
+    public enum LogLevel
+    {
+        None = 0,
+        Minimal = 1,
+        Default = 2,
+        Verbose = 3,
+        Debug = 4,
+        Insanity = 5,
+    }
+
+    public enum ProcessType
+    {
+        File,
+        Directory,
     }
 }

--- a/XamlStyler.Console/Program.cs
+++ b/XamlStyler.Console/Program.cs
@@ -214,7 +214,7 @@ namespace Xavalon.XamlStyler.Xmagic
     public sealed class CommandLineOptions
     {
         [Option('f', "file", Separator = ',', HelpText = "XAML file to process (supports comma-separated list).")]
-        public IList<string> File { get; set; }
+        public IList<string> File { get; private set; }
 
         [Option('d', "directory", HelpText = "Directory to process XAML files in.")]
         public string Directory { get; set; }

--- a/XamlStyler.Console/XamlStyler.Console.csproj
+++ b/XamlStyler.Console/XamlStyler.Console.csproj
@@ -25,6 +25,10 @@
     <PackageReference Include="CommandLineParser">
       <Version>2.6.0</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>12.0.3</Version>
     </PackageReference>

--- a/XamlStyler.Console/XamlStylerConsole.cs
+++ b/XamlStyler.Console/XamlStylerConsole.cs
@@ -13,10 +13,10 @@ namespace Xavalon.XamlStyler.Xmagic
 {
     public sealed class XamlStylerConsole
     {
-        private readonly Options options;
+        private readonly CommandLineOptions options;
         private readonly StylerService stylerService;
 
-        public XamlStylerConsole(Options options)
+        public XamlStylerConsole(CommandLineOptions options)
         {
             this.options = options;
 
@@ -32,7 +32,7 @@ namespace Xavalon.XamlStyler.Xmagic
             this.stylerService = new StylerService(stylerOptions);
         }
 
-        private void ApplyOptionOverrides(Options options, IStylerOptions stylerOptions)
+        private void ApplyOptionOverrides(CommandLineOptions options, IStylerOptions stylerOptions)
         {
             if (options.IndentSize != null)
             {

--- a/XamlStyler.Core/DocumentManipulation/AttributeRemovalService.cs
+++ b/XamlStyler.Core/DocumentManipulation/AttributeRemovalService.cs
@@ -67,7 +67,7 @@ namespace Xavalon.XamlStyler.Core.DocumentManipulation
                         foreach (AttributeSelector attribute in this.initializedAttributes)
                         {
                             if (attribute.IsMatch(elementAttribute)
-                                && (String.IsNullOrEmpty(attribute.Value) || attribute.Value.Equals(elementAttribute.Value)))
+                                && (String.IsNullOrEmpty(attribute.Value) || attribute.Value.Equals(elementAttribute.Value, StringComparison.Ordinal)))
                             {
                                 removedAttributeList.Add(elementAttribute);
                                 continue;

--- a/XamlStyler.Core/DocumentManipulation/DocumentManipulationService.cs
+++ b/XamlStyler.Core/DocumentManipulation/DocumentManipulationService.cs
@@ -106,7 +106,7 @@ namespace Xavalon.XamlStyler.Core.DocumentManipulation
                     break;
 
                 default:
-                    throw new ArgumentOutOfRangeException();
+                    throw new NotImplementedException();
             }
 
             return reorderService;

--- a/XamlStyler.Core/DocumentManipulation/NodeCollection.cs
+++ b/XamlStyler.Core/DocumentManipulation/NodeCollection.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Xml.Linq;
 
 namespace Xavalon.XamlStyler.Core.DocumentManipulation
@@ -59,6 +60,7 @@ namespace Xavalon.XamlStyler.Core.DocumentManipulation
         public override string ToString()
         {
             return String.Format(
+                CultureInfo.InvariantCulture,
                 "B{0} A{1} N{2}",
                 this.BlockIndex,
                 String.Join("|", (IEnumerable<ISortableAttribute>)this.SortAttributeValues),

--- a/XamlStyler.Core/DocumentManipulation/NodeCollection.cs
+++ b/XamlStyler.Core/DocumentManipulation/NodeCollection.cs
@@ -2,11 +2,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Xml.Linq;
 
 namespace Xavalon.XamlStyler.Core.DocumentManipulation
 {
+    // TODO: Investiagate why we need to supress this warning.
+    [SuppressMessage("Design", "CA1036:Override methods on comparable types", Justification = "Introduces breaking change")]
     public class NodeCollection : IComparable<NodeCollection>
     {
         /// <summary>

--- a/XamlStyler.Core/DocumentManipulation/NodeCollection.cs
+++ b/XamlStyler.Core/DocumentManipulation/NodeCollection.cs
@@ -8,7 +8,7 @@ using System.Xml.Linq;
 
 namespace Xavalon.XamlStyler.Core.DocumentManipulation
 {
-    // TODO: Investiagate why we need to supress this warning.
+    // TODO: Fully implement IComparable interface.
     [SuppressMessage("Design", "CA1036:Override methods on comparable types", Justification = "Introduces breaking change")]
     public class NodeCollection : IComparable<NodeCollection>
     {

--- a/XamlStyler.Core/DocumentManipulation/NodeCollection.cs
+++ b/XamlStyler.Core/DocumentManipulation/NodeCollection.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Xml.Linq;
@@ -25,7 +26,12 @@ namespace Xavalon.XamlStyler.Core.DocumentManipulation
         /// <summary>
         /// This is the collection of attributes for this node
         /// </summary>
-        public ISortableAttribute[] SortAttributeValues { get; set; }
+        public Collection<ISortableAttribute> SortAttributeValues { get; private set; }
+
+        public void SetSortAttributeValues(Collection<ISortableAttribute> collection)
+        {
+            this.SortAttributeValues = collection;
+        }
 
         public NodeCollection()
         {
@@ -42,10 +48,10 @@ namespace Xavalon.XamlStyler.Core.DocumentManipulation
             var result = this.BlockIndex.CompareTo(other.BlockIndex);
             if (result == 0)
             {
-                result = this.SortAttributeValues.Length.CompareTo(other.SortAttributeValues.Length);
+                result = this.SortAttributeValues.Count.CompareTo(other.SortAttributeValues.Count);
                 if (result == 0)
                 {
-                    for (int i = 0; i < this.SortAttributeValues.Length; i++)
+                    for (int i = 0; i < this.SortAttributeValues.Count; i++)
                     {
                         result = this.SortAttributeValues[i].CompareTo(other.SortAttributeValues[i]);
                         if (result != 0)

--- a/XamlStyler.Core/DocumentManipulation/NodeReorderService.cs
+++ b/XamlStyler.Core/DocumentManipulation/NodeReorderService.cs
@@ -1,6 +1,7 @@
 ﻿// © Xavalon. All rights reserved.
 
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
@@ -92,8 +93,8 @@ namespace Xavalon.XamlStyler.Core.DocumentManipulation
 
                     if (isMatchingChild)
                     {
-                        currentNodeCollection.SortAttributeValues =
-                            this.SortByAttributes.Select(_ => _.GetValue(childElement)).ToArray();
+                        currentNodeCollection.SetSortAttributeValues(
+                            new Collection<ISortableAttribute>(this.SortByAttributes.Select(_ => _.GetValue(childElement)).ToArray()));
                     }
 
                     currentNodeCollection.BlockIndex = childBlockIndex;

--- a/XamlStyler.Core/DocumentManipulation/SortBy.cs
+++ b/XamlStyler.Core/DocumentManipulation/SortBy.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Xml.Linq;
 
@@ -48,7 +49,7 @@ namespace Xavalon.XamlStyler.Core.DocumentManipulation
             }
 
             return this.IsNumeric
-                ? (ISortableAttribute)new SortableNumericAttribute(value, Double.Parse(this.defaultValue(element)))
+                ? (ISortableAttribute)new SortableNumericAttribute(value, Double.Parse(this.defaultValue(element), CultureInfo.InvariantCulture))
                 : (ISortableAttribute)new SortableStringAttribute(value ?? this.defaultValue(element));
         }
     }

--- a/XamlStyler.Core/DocumentManipulation/SortableNumericAttribute.cs
+++ b/XamlStyler.Core/DocumentManipulation/SortableNumericAttribute.cs
@@ -33,6 +33,61 @@ namespace Xavalon.XamlStyler.Core.DocumentManipulation
             return result;
         }
 
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (ReferenceEquals(obj, null))
+            {
+                return false;
+            }
+
+            throw new NotImplementedException();
+        }
+
+        public override int GetHashCode()
+        {
+            throw new NotImplementedException();
+        }
+
+        public static bool operator ==(SortableNumericAttribute left, SortableNumericAttribute right)
+        {
+            if (ReferenceEquals(left, null))
+            {
+                return ReferenceEquals(right, null);
+            }
+
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(SortableNumericAttribute left, SortableNumericAttribute right)
+        {
+            return !(left == right);
+        }
+
+        public static bool operator <(SortableNumericAttribute left, SortableNumericAttribute right)
+        {
+            return ReferenceEquals(left, null) ? !ReferenceEquals(right, null) : left.CompareTo(right) < 0;
+        }
+
+        public static bool operator <=(SortableNumericAttribute left, SortableNumericAttribute right)
+        {
+            return ReferenceEquals(left, null) || left.CompareTo(right) <= 0;
+        }
+
+        public static bool operator >(SortableNumericAttribute left, SortableNumericAttribute right)
+        {
+            return !ReferenceEquals(left, null) && left.CompareTo(right) > 0;
+        }
+
+        public static bool operator >=(SortableNumericAttribute left, SortableNumericAttribute right)
+        {
+            return ReferenceEquals(left, null) ? ReferenceEquals(right, null) : left.CompareTo(right) >= 0;
+        }
+
 #if DEBUG
         public override string ToString()
         {

--- a/XamlStyler.Core/DocumentManipulation/SortableNumericAttribute.cs
+++ b/XamlStyler.Core/DocumentManipulation/SortableNumericAttribute.cs
@@ -1,9 +1,12 @@
 // © Xavalon. All rights reserved.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Xavalon.XamlStyler.Core.DocumentManipulation
 {
+    // TODO: Fully implement IComparable interface.
+    [SuppressMessage("Design", "CA1036:Override methods on comparable types", Justification = "No clear ROI and introduces more warnings")]
     public class SortableNumericAttribute : ISortableAttribute
     {
         public string Value { get; private set; }
@@ -31,61 +34,6 @@ namespace Xavalon.XamlStyler.Core.DocumentManipulation
             }
 
             return result;
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(this, obj))
-            {
-                return true;
-            }
-
-            if (ReferenceEquals(obj, null))
-            {
-                return false;
-            }
-
-            throw new NotImplementedException();
-        }
-
-        public override int GetHashCode()
-        {
-            throw new NotImplementedException();
-        }
-
-        public static bool operator ==(SortableNumericAttribute left, SortableNumericAttribute right)
-        {
-            if (ReferenceEquals(left, null))
-            {
-                return ReferenceEquals(right, null);
-            }
-
-            return left.Equals(right);
-        }
-
-        public static bool operator !=(SortableNumericAttribute left, SortableNumericAttribute right)
-        {
-            return !(left == right);
-        }
-
-        public static bool operator <(SortableNumericAttribute left, SortableNumericAttribute right)
-        {
-            return ReferenceEquals(left, null) ? !ReferenceEquals(right, null) : left.CompareTo(right) < 0;
-        }
-
-        public static bool operator <=(SortableNumericAttribute left, SortableNumericAttribute right)
-        {
-            return ReferenceEquals(left, null) || left.CompareTo(right) <= 0;
-        }
-
-        public static bool operator >(SortableNumericAttribute left, SortableNumericAttribute right)
-        {
-            return !ReferenceEquals(left, null) && left.CompareTo(right) > 0;
-        }
-
-        public static bool operator >=(SortableNumericAttribute left, SortableNumericAttribute right)
-        {
-            return ReferenceEquals(left, null) ? ReferenceEquals(right, null) : left.CompareTo(right) >= 0;
         }
 
 #if DEBUG

--- a/XamlStyler.Core/DocumentManipulation/SortableNumericAttribute.cs
+++ b/XamlStyler.Core/DocumentManipulation/SortableNumericAttribute.cs
@@ -17,8 +17,7 @@ namespace Xavalon.XamlStyler.Core.DocumentManipulation
         {
             this.Value = value;
 
-            double numericValue;
-            this.NumericValue = Double.TryParse(value, out numericValue)
+            this.NumericValue = Double.TryParse(value, out double numericValue)
                 ? numericValue
                 : defaultNumericValue;
         }

--- a/XamlStyler.Core/DocumentManipulation/SortableStringAttribute.cs
+++ b/XamlStyler.Core/DocumentManipulation/SortableStringAttribute.cs
@@ -1,9 +1,12 @@
 // © Xavalon. All rights reserved.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Xavalon.XamlStyler.Core.DocumentManipulation
 {
+    // TODO: Fully implement IComparable interface.
+    [SuppressMessage("Design", "CA1036:Override methods on comparable types", Justification = "No clear ROI and introduces more warnings")]
     public class SortableStringAttribute : ISortableAttribute
     {
         public string Value { get; private set; }
@@ -16,61 +19,6 @@ namespace Xavalon.XamlStyler.Core.DocumentManipulation
         public int CompareTo(ISortableAttribute other)
         {
             return String.Compare(this.Value, ((SortableStringAttribute)other).Value, StringComparison.Ordinal);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(this, obj))
-            {
-                return true;
-            }
-
-            if (ReferenceEquals(obj, null))
-            {
-                return false;
-            }
-
-            throw new NotImplementedException();
-        }
-
-        public override int GetHashCode()
-        {
-            throw new NotImplementedException();
-        }
-
-        public static bool operator ==(SortableStringAttribute left, SortableStringAttribute right)
-        {
-            if (ReferenceEquals(left, null))
-            {
-                return ReferenceEquals(right, null);
-            }
-
-            return left.Equals(right);
-        }
-
-        public static bool operator !=(SortableStringAttribute left, SortableStringAttribute right)
-        {
-            return !(left == right);
-        }
-
-        public static bool operator <(SortableStringAttribute left, SortableStringAttribute right)
-        {
-            return ReferenceEquals(left, null) ? !ReferenceEquals(right, null) : left.CompareTo(right) < 0;
-        }
-
-        public static bool operator <=(SortableStringAttribute left, SortableStringAttribute right)
-        {
-            return ReferenceEquals(left, null) || left.CompareTo(right) <= 0;
-        }
-
-        public static bool operator >(SortableStringAttribute left, SortableStringAttribute right)
-        {
-            return !ReferenceEquals(left, null) && left.CompareTo(right) > 0;
-        }
-
-        public static bool operator >=(SortableStringAttribute left, SortableStringAttribute right)
-        {
-            return ReferenceEquals(left, null) ? ReferenceEquals(right, null) : left.CompareTo(right) >= 0;
         }
 
 #if DEBUG

--- a/XamlStyler.Core/DocumentManipulation/SortableStringAttribute.cs
+++ b/XamlStyler.Core/DocumentManipulation/SortableStringAttribute.cs
@@ -18,6 +18,61 @@ namespace Xavalon.XamlStyler.Core.DocumentManipulation
             return String.Compare(this.Value, ((SortableStringAttribute)other).Value, StringComparison.Ordinal);
         }
 
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (ReferenceEquals(obj, null))
+            {
+                return false;
+            }
+
+            throw new NotImplementedException();
+        }
+
+        public override int GetHashCode()
+        {
+            throw new NotImplementedException();
+        }
+
+        public static bool operator ==(SortableStringAttribute left, SortableStringAttribute right)
+        {
+            if (ReferenceEquals(left, null))
+            {
+                return ReferenceEquals(right, null);
+            }
+
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(SortableStringAttribute left, SortableStringAttribute right)
+        {
+            return !(left == right);
+        }
+
+        public static bool operator <(SortableStringAttribute left, SortableStringAttribute right)
+        {
+            return ReferenceEquals(left, null) ? !ReferenceEquals(right, null) : left.CompareTo(right) < 0;
+        }
+
+        public static bool operator <=(SortableStringAttribute left, SortableStringAttribute right)
+        {
+            return ReferenceEquals(left, null) || left.CompareTo(right) <= 0;
+        }
+
+        public static bool operator >(SortableStringAttribute left, SortableStringAttribute right)
+        {
+            return !ReferenceEquals(left, null) && left.CompareTo(right) > 0;
+        }
+
+        public static bool operator >=(SortableStringAttribute left, SortableStringAttribute right)
+        {
+            return ReferenceEquals(left, null) ? ReferenceEquals(right, null) : left.CompareTo(right) >= 0;
+        }
+
 #if DEBUG
         public override string ToString()
         {

--- a/XamlStyler.Core/DocumentManipulation/VSMReorderService.cs
+++ b/XamlStyler.Core/DocumentManipulation/VSMReorderService.cs
@@ -1,5 +1,6 @@
 ﻿// © Xavalon. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
@@ -77,7 +78,7 @@ namespace Xavalon.XamlStyler.Core.DocumentManipulation
                         vsmNodeCollection = currentNodeCollection;
                         hasCollectionBeenAdded = true;
                     }
-                    else if(childName.LocalName.StartsWith($"{parentName.LocalName}."))
+                    else if(childName.LocalName.StartsWith($"{parentName.LocalName}.", StringComparison.Ordinal))
                     {
                         // Extract property-element syntax nodes.
                         propertyElementCollection.Add(currentNodeCollection);

--- a/XamlStyler.Core/DocumentManipulation/VSMReorderService.cs
+++ b/XamlStyler.Core/DocumentManipulation/VSMReorderService.cs
@@ -10,7 +10,7 @@ namespace Xavalon.XamlStyler.Core.DocumentManipulation
 {
     public class VSMReorderService : IProcessElementService
     {
-        public readonly NameSelector VSMNode = new NameSelector("VisualStateManager.VisualStateGroups", null);
+        private readonly NameSelector VSMNode = new NameSelector("VisualStateManager.VisualStateGroups", null);
 
         public VisualStateManagerRule Mode { get; set; } = VisualStateManagerRule.None;
 

--- a/XamlStyler.Core/DocumentProcessors/CDATADocumentProcessor.cs
+++ b/XamlStyler.Core/DocumentProcessors/CDATADocumentProcessor.cs
@@ -24,7 +24,7 @@ namespace Xavalon.XamlStyler.Core.DocumentProcessors
             // indent accordingly, otherwise treat as single line text.
             if (output.IsNewLine())
             {
-                elementProcessContext.UpdateParentElementProcessStatus(ContentTypeEnum.MultiLineTextOnly);
+                elementProcessContext.UpdateParentElementProcessStatus(ContentTypes.MultiLineTextOnly);
                 if (!elementProcessContext.Current.IsPreservingSpace)
                 {
                     string currentIndentString = this.indentService.GetIndentString(xmlReader.Depth);
@@ -33,7 +33,7 @@ namespace Xavalon.XamlStyler.Core.DocumentProcessors
             }
             else
             {
-                elementProcessContext.UpdateParentElementProcessStatus(ContentTypeEnum.SingleLineTextOnly);
+                elementProcessContext.UpdateParentElementProcessStatus(ContentTypes.SingleLineTextOnly);
             }
 
             // All newlines are returned by XmlReader as '\n' due to requirements in the XML Specification.

--- a/XamlStyler.Core/DocumentProcessors/CommentDocumentProcessor.cs
+++ b/XamlStyler.Core/DocumentProcessors/CommentDocumentProcessor.cs
@@ -43,7 +43,7 @@ namespace Xavalon.XamlStyler.Core.DocumentProcessors
                 {
                     output.Append(String.Join(Environment.NewLine, content.GetLines().Select(_ => _.TrimEnd(' '))));
 
-                    if (content.TrimEnd(' ').EndsWith("\n"))
+                    if (content.TrimEnd(' ').EndsWith("\n", StringComparison.Ordinal))
                     {
                         output.Append(currentIndentString);
                     }

--- a/XamlStyler.Core/DocumentProcessors/CommentDocumentProcessor.cs
+++ b/XamlStyler.Core/DocumentProcessors/CommentDocumentProcessor.cs
@@ -24,7 +24,7 @@ namespace Xavalon.XamlStyler.Core.DocumentProcessors
 
         public void Process(XmlReader xmlReader, StringBuilder output, ElementProcessContext elementProcessContext)
         {
-            elementProcessContext.UpdateParentElementProcessStatus(ContentTypeEnum.Mixed);
+            elementProcessContext.UpdateParentElementProcessStatus(ContentTypes.Mixed);
 
             string currentIndentString = this.indentService.GetIndentString(xmlReader.Depth);
             string content = xmlReader.Value;

--- a/XamlStyler.Core/DocumentProcessors/ElementDocumentProcessor.cs
+++ b/XamlStyler.Core/DocumentProcessors/ElementDocumentProcessor.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Xml;
@@ -275,7 +276,7 @@ namespace Xavalon.XamlStyler.Core.DocumentProcessors
                             xmlnsAliasesBypassLengthInCurrentLine = 0;
                         }
 
-                        currentLineBuffer.AppendFormat("{0} ", pendingAppend);
+                        currentLineBuffer.AppendFormat(CultureInfo.InvariantCulture, "{0} ", pendingAppend);
                         attributeCountInCurrentLineBuffer++;
                         xmlnsAliasesBypassLengthInCurrentLine += pendingAppend.Length - actualPendingAppend.Length;
                     }

--- a/XamlStyler.Core/DocumentProcessors/ElementDocumentProcessor.cs
+++ b/XamlStyler.Core/DocumentProcessors/ElementDocumentProcessor.cs
@@ -45,7 +45,7 @@ namespace Xavalon.XamlStyler.Core.DocumentProcessors
 
         public void Process(XmlReader xmlReader, StringBuilder output, ElementProcessContext elementProcessContext)
         {
-            elementProcessContext.UpdateParentElementProcessStatus(ContentTypeEnum.Mixed);
+            elementProcessContext.UpdateParentElementProcessStatus(ContentTypes.Mixed);
 
             var elementName = xmlReader.Name;
             elementProcessContext.Push(
@@ -53,7 +53,7 @@ namespace Xavalon.XamlStyler.Core.DocumentProcessors
                 {
                     Parent = elementProcessContext.Current,
                     Name = elementName,
-                    ContentType = ContentTypeEnum.None,
+                    ContentType = ContentTypes.None,
                     IsMultlineStartTag = false,
                     IsPreservingSpace = elementProcessContext.Current.IsPreservingSpace
                 });

--- a/XamlStyler.Core/DocumentProcessors/ElementDocumentProcessor.cs
+++ b/XamlStyler.Core/DocumentProcessors/ElementDocumentProcessor.cs
@@ -193,7 +193,7 @@ namespace Xavalon.XamlStyler.Core.DocumentProcessors
                         break;
 
                     default:
-                        throw new ArgumentOutOfRangeException();
+                        throw new NotImplementedException();
                 }
             }
 

--- a/XamlStyler.Core/DocumentProcessors/ElementProcessContext.cs
+++ b/XamlStyler.Core/DocumentProcessors/ElementProcessContext.cs
@@ -29,7 +29,7 @@ namespace Xavalon.XamlStyler.Core.DocumentProcessors
             return this.elementProcessStatusStack.Pop();
         }
 
-        public void UpdateParentElementProcessStatus(ContentTypeEnum contentType)
+        public void UpdateParentElementProcessStatus(ContentTypes contentType)
         {
             ElementProcessStatus parentElementProcessStatus = this.elementProcessStatusStack.Peek();
             parentElementProcessStatus.ContentType |= contentType;

--- a/XamlStyler.Core/DocumentProcessors/EndElementDocumentProcessor.cs
+++ b/XamlStyler.Core/DocumentProcessors/EndElementDocumentProcessor.cs
@@ -34,7 +34,7 @@ namespace Xavalon.XamlStyler.Core.DocumentProcessors
             {
                 output.Append("</").Append(xmlReader.Name).Append(">");
             }
-            else if ((elementProcessContext.Current.ContentType == ContentTypeEnum.None)
+            else if ((elementProcessContext.Current.ContentType == ContentTypes.None)
                 && this.options.RemoveEndingTagOfEmptyElement)
             {
                 // Shrink the current element, if it has no content.
@@ -51,7 +51,7 @@ namespace Xavalon.XamlStyler.Core.DocumentProcessors
                     output.Insert(bracketIndex, ' ');
                 }
             }
-            else if ((elementProcessContext.Current.ContentType == ContentTypeEnum.SingleLineTextOnly)
+            else if ((elementProcessContext.Current.ContentType == ContentTypes.SingleLineTextOnly)
                 && !elementProcessContext.Current.IsMultlineStartTag)
             {
                 int bracketIndex = output.LastIndexOf('>');

--- a/XamlStyler.Core/DocumentProcessors/ProcessInstructionDocumentProcessor.cs
+++ b/XamlStyler.Core/DocumentProcessors/ProcessInstructionDocumentProcessor.cs
@@ -20,7 +20,7 @@ namespace Xavalon.XamlStyler.Core.DocumentProcessors
 
         public void Process(XmlReader xmlReader, StringBuilder output, ElementProcessContext elementProcessContext)
         {
-            elementProcessContext.UpdateParentElementProcessStatus(ContentTypeEnum.Mixed);
+            elementProcessContext.UpdateParentElementProcessStatus(ContentTypes.Mixed);
 
             string currentIndentString = this.indentService.GetIndentString(xmlReader.Depth);
 

--- a/XamlStyler.Core/DocumentProcessors/TextDocumentProcessor.cs
+++ b/XamlStyler.Core/DocumentProcessors/TextDocumentProcessor.cs
@@ -22,7 +22,7 @@ namespace Xavalon.XamlStyler.Core.DocumentProcessors
 
         public void Process(XmlReader xmlReader, StringBuilder output, ElementProcessContext elementProcessContext)
         {
-            elementProcessContext.UpdateParentElementProcessStatus(ContentTypeEnum.SingleLineTextOnly);
+            elementProcessContext.UpdateParentElementProcessStatus(ContentTypes.SingleLineTextOnly);
 
             var xmlEncodedContent = xmlReader.Value.ToXmlEncodedString(ignoreCarrier: true);
             if (elementProcessContext.Current.IsPreservingSpace)
@@ -49,7 +49,7 @@ namespace Xavalon.XamlStyler.Core.DocumentProcessors
 
             if (xmlEncodedContent.Any(_ => (_ == '\n')))
             {
-                elementProcessContext.UpdateParentElementProcessStatus(ContentTypeEnum.MultiLineTextOnly);
+                elementProcessContext.UpdateParentElementProcessStatus(ContentTypes.MultiLineTextOnly);
             }
         }
     }

--- a/XamlStyler.Core/Extensions/ListExtensions.cs
+++ b/XamlStyler.Core/Extensions/ListExtensions.cs
@@ -11,12 +11,12 @@ namespace Xavalon.XamlStyler.Core.Extensions
         {
             if (list == null)
             {
-                throw new ArgumentNullException("list");
+                throw new ArgumentNullException(nameof(list));
             }
 
             if (comparison == null)
             {
-                throw new ArgumentNullException("comparison");
+                throw new ArgumentNullException(nameof(comparison));
             }
 
             int count = list.Count;

--- a/XamlStyler.Core/Extensions/XmlReaderExtensions.cs
+++ b/XamlStyler.Core/Extensions/XmlReaderExtensions.cs
@@ -13,7 +13,7 @@ namespace Xavalon.XamlStyler.Core.Extensions
         /// <returns>true if xml:space</returns>
         public static bool IsXmlSpaceAttribute(this XmlReader xmlReader)
         {
-            return (xmlReader.Name.ToLowerInvariant() == "xml:space");
+            return (xmlReader.Name.ToUpperInvariant() == "XML:SPACE");
         }
     }
 }

--- a/XamlStyler.Core/MarkupExtensions/Formatter/AttributeInfoFormatter.cs
+++ b/XamlStyler.Core/MarkupExtensions/Formatter/AttributeInfoFormatter.cs
@@ -1,6 +1,7 @@
 // © Xavalon. All rights reserved.
 
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -46,7 +47,7 @@ namespace Xavalon.XamlStyler.Core.MarkupExtensions.Formatter
                 var lines = this.formatter.Format(attrInfo.MarkupExtension);
 
                 var buffer = new StringBuilder();
-                buffer.AppendFormat("{0}=\"{1}", attrInfo.Name, lines.First());
+                buffer.AppendFormat(CultureInfo.InvariantCulture, "{0}=\"{1}", attrInfo.Name, lines.First());
                 foreach (var line in lines.Skip(1))
                 {
                     buffer.AppendLine();

--- a/XamlStyler.Core/MarkupExtensions/Formatter/MarkupExtensionFormatterBase.cs
+++ b/XamlStyler.Core/MarkupExtensions/Formatter/MarkupExtensionFormatterBase.cs
@@ -19,7 +19,7 @@ namespace Xavalon.XamlStyler.Core.MarkupExtensions.Formatter
         public IEnumerable<string> FormatArguments(MarkupExtension markupExtension, bool isNested = false)
         {
             return markupExtension.Arguments.Any()
-                ? this.Format($"{{{markupExtension.TypeName} ", this.FormatArguments(markupExtension.Arguments, isNested: isNested), "}")
+                ? MarkupExtensionFormatterBase.Format($"{{{markupExtension.TypeName} ", this.FormatArguments(markupExtension.Arguments, isNested: isNested), "}")
                 : new string[] { $"{{{markupExtension.TypeName}}}" };
         }
 
@@ -51,7 +51,7 @@ namespace Xavalon.XamlStyler.Core.MarkupExtensions.Formatter
             throw new ArgumentException($"Unhandled type {type.FullName}", nameof(argument));
         }
 
-        private IEnumerable<string> Format(string prefix, IEnumerable<string> lines, string suffix = null)
+        private static IEnumerable<string> Format(string prefix, IEnumerable<string> lines, string suffix = null)
         {
             var list = new List<string>();
 
@@ -69,7 +69,7 @@ namespace Xavalon.XamlStyler.Core.MarkupExtensions.Formatter
 
         private IEnumerable<string> FormatNamedArgument(NamedArgument namedArgument)
         {
-            return this.Format($"{namedArgument.Name}=", this.FormatValue(namedArgument.Value));
+            return MarkupExtensionFormatterBase.Format($"{namedArgument.Name}=", this.FormatValue(namedArgument.Value));
         }
 
         private IEnumerable<string> FormatPositionalArgument(PositionalArgument positionalArgument)
@@ -77,7 +77,7 @@ namespace Xavalon.XamlStyler.Core.MarkupExtensions.Formatter
             return this.FormatValue(positionalArgument.Value);
         }
 
-        private IEnumerable<string> FormatLiteralValue(LiteralValue literalValue)
+        private static IEnumerable<string> FormatLiteralValue(LiteralValue literalValue)
         {
             return new[]
             {
@@ -91,7 +91,7 @@ namespace Xavalon.XamlStyler.Core.MarkupExtensions.Formatter
 
             if (type == typeof(LiteralValue))
             {
-                return this.FormatLiteralValue((LiteralValue)value);
+                return MarkupExtensionFormatterBase.FormatLiteralValue((LiteralValue)value);
             }
 
             if (type == typeof(MarkupExtension))

--- a/XamlStyler.Core/MarkupExtensions/Formatter/MarkupExtensionFormatterBase.cs
+++ b/XamlStyler.Core/MarkupExtensions/Formatter/MarkupExtensionFormatterBase.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using Xavalon.XamlStyler.Core.MarkupExtensions.Parser;
 
@@ -23,7 +24,7 @@ namespace Xavalon.XamlStyler.Core.MarkupExtensions.Formatter
                 : new string[] { $"{{{markupExtension.TypeName}}}" };
         }
 
-        protected abstract IEnumerable<string> FormatArguments(Argument[] arguments, bool isNested = false);
+        protected abstract IEnumerable<string> FormatArguments(Collection<Argument> arguments, bool isNested = false);
 
         protected IEnumerable<string> FormatArgument(Argument argument, bool isNested = false)
         {

--- a/XamlStyler.Core/MarkupExtensions/Formatter/MultiLineMarkupExtensionFormatter.cs
+++ b/XamlStyler.Core/MarkupExtensions/Formatter/MultiLineMarkupExtensionFormatter.cs
@@ -1,6 +1,7 @@
 // © Xavalon. All rights reserved.
 
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Xavalon.XamlStyler.Core.MarkupExtensions.Parser;
 
 namespace Xavalon.XamlStyler.Core.MarkupExtensions.Formatter
@@ -12,7 +13,7 @@ namespace Xavalon.XamlStyler.Core.MarkupExtensions.Formatter
         {
         }
 
-        protected override IEnumerable<string> FormatArguments(Argument[] arguments, bool isNested = false)
+        protected override IEnumerable<string> FormatArguments(Collection<Argument> arguments, bool isNested = false)
         {
             var list = new List<string>();
             string deferred = null;

--- a/XamlStyler.Core/MarkupExtensions/Formatter/SingleLineMarkupExtensionFormatter.cs
+++ b/XamlStyler.Core/MarkupExtensions/Formatter/SingleLineMarkupExtensionFormatter.cs
@@ -1,6 +1,7 @@
 // © Xavalon. All rights reserved.
 
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Text;
 using Xavalon.XamlStyler.Core.MarkupExtensions.Parser;
 
@@ -13,7 +14,7 @@ namespace Xavalon.XamlStyler.Core.MarkupExtensions.Formatter
         {
         }
 
-        protected override IEnumerable<string> FormatArguments(Argument[] arguments, bool isNested = false)
+        protected override IEnumerable<string> FormatArguments(Collection<Argument> arguments, bool isNested = false)
         {
             StringBuilder stringBuilder = new StringBuilder();
             foreach (var argument in arguments)

--- a/XamlStyler.Core/MarkupExtensions/Parser/MarkupExtension.cs
+++ b/XamlStyler.Core/MarkupExtensions/Parser/MarkupExtension.cs
@@ -3,6 +3,7 @@
 using Irony.Parsing;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 
 namespace Xavalon.XamlStyler.Core.MarkupExtensions.Parser
@@ -11,7 +12,7 @@ namespace Xavalon.XamlStyler.Core.MarkupExtensions.Parser
     {
         public string TypeName { get; }
 
-        public Argument[] Arguments { get; }
+        public Collection<Argument> Arguments { get; }
 
         public MarkupExtension(string typeName, params Argument[] arguments)
         {
@@ -26,7 +27,7 @@ namespace Xavalon.XamlStyler.Core.MarkupExtensions.Parser
             }
 
             this.TypeName = typeName;
-            this.Arguments = arguments;
+            this.Arguments = new Collection<Argument>(arguments);
         }
 
         public static new MarkupExtension Create(ParseTreeNode node)

--- a/XamlStyler.Core/MarkupExtensions/Parser/Value.cs
+++ b/XamlStyler.Core/MarkupExtensions/Parser/Value.cs
@@ -1,6 +1,7 @@
 ﻿// © Xavalon. All rights reserved.
 
 using Irony.Parsing;
+using System;
 
 namespace Xavalon.XamlStyler.Core.MarkupExtensions.Parser
 {
@@ -14,6 +15,11 @@ namespace Xavalon.XamlStyler.Core.MarkupExtensions.Parser
         public static implicit operator Value(string value)
         {
             return new LiteralValue(value);
+        }
+
+        public Value ToValue()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/XamlStyler.Core/Model/AttributeOrderRule.cs
+++ b/XamlStyler.Core/Model/AttributeOrderRule.cs
@@ -1,5 +1,6 @@
 ﻿// © Xavalon. All rights reserved.
 
+using System;
 using System.Linq;
 using Xavalon.XamlStyler.Core.DocumentManipulation;
 
@@ -26,7 +27,7 @@ namespace Xavalon.XamlStyler.Core.Model
             // -1 = Contains '*'  
             //  0 = Contains '?'  
             //  1 = No Wildcards  
-            this.MatchScore = (name.Equals("*") || name.Equals("*:*"))
+            this.MatchScore = (name.Equals("*", StringComparison.Ordinal) || name.Equals("*:*", StringComparison.Ordinal))
                 ? -2
                 : name.Any(_ => (_ == '*'))
                     ? -1

--- a/XamlStyler.Core/Options/IStylerOptions.cs
+++ b/XamlStyler.Core/Options/IStylerOptions.cs
@@ -1,5 +1,6 @@
 // © Xavalon. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using Xavalon.XamlStyler.Core.DocumentManipulation;
 
 namespace Xavalon.XamlStyler.Core.Options
@@ -47,6 +48,7 @@ namespace Xavalon.XamlStyler.Core.Options
 
         bool EnableAttributeReordering { get; set; }
 
+        [SuppressMessage("Performance", "CA1819:Properties should not return arrays", Justification = "Required for serialization/deserialization")]
         string[] AttributeOrderingRuleGroups { get; set; }
 
         bool OrderAttributesByName { get; set; }

--- a/XamlStyler.Core/Options/StylerOptions.cs
+++ b/XamlStyler.Core/Options/StylerOptions.cs
@@ -381,13 +381,13 @@ namespace Xavalon.XamlStyler.Core.Options
                     foreach (PropertyDescriptor propertyDescriptor in TypeDescriptor.GetProperties(this))
                     {
                         // Cannot set Config Path from External Configuration.
-                        if (propertyDescriptor.Name.Equals(nameof(this.ConfigPath)))
+                        if (propertyDescriptor.Name.Equals(nameof(this.ConfigPath), StringComparison.Ordinal))
                         {
                             continue;
                         }
 
                         // If a valid IndentSize is specified in configuration, do not load VS settings.
-                        if (propertyDescriptor.Name.Equals(nameof(this.IndentSize)))
+                        if (propertyDescriptor.Name.Equals(nameof(this.IndentSize), StringComparison.Ordinal))
                         {
                             int indentSize;
                             try

--- a/XamlStyler.Core/Options/StylerOptions.cs
+++ b/XamlStyler.Core/Options/StylerOptions.cs
@@ -3,6 +3,7 @@
 using Newtonsoft.Json;
 using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
@@ -39,6 +40,8 @@ namespace Xavalon.XamlStyler.Core.Options
         /// </summary>
         /// <param name="isJsonConstructor">Dummy parameter to differentiate from default constructor.</param>
         [JsonConstructor]
+        [SuppressMessage("Usage", "CA1801:Review unused parameters", Justification = "Required for deserialization", MessageId = "isJsonConstructor")]
+        [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Required for deserialization")]
         public StylerOptions(bool isJsonConstructor = true) { }
 
         // Indentation

--- a/XamlStyler.Core/Options/StylerOptions.cs
+++ b/XamlStyler.Core/Options/StylerOptions.cs
@@ -434,10 +434,7 @@ namespace Xavalon.XamlStyler.Core.Options
             foreach (PropertyDescriptor propertyDescriptor in TypeDescriptor.GetProperties(this))
             {
                 // Set default value if DefaultValueAttribute is present
-                DefaultValueAttribute attribute
-                    = propertyDescriptor.Attributes[typeof(DefaultValueAttribute)] as DefaultValueAttribute;
-
-                if (attribute != null)
+                if (propertyDescriptor.Attributes[typeof(DefaultValueAttribute)] is DefaultValueAttribute attribute)
                 {
                     propertyDescriptor.SetValue(this, attribute.Value);
                 }

--- a/XamlStyler.Core/Options/StylerOptions.cs
+++ b/XamlStyler.Core/Options/StylerOptions.cs
@@ -3,6 +3,7 @@
 using Newtonsoft.Json;
 using System;
 using System.ComponentModel;
+using System.Globalization;
 using System.IO;
 using System.Reflection;
 using Xavalon.XamlStyler.Core.DocumentManipulation;
@@ -391,7 +392,7 @@ namespace Xavalon.XamlStyler.Core.Options
                             int indentSize;
                             try
                             {
-                                indentSize = Convert.ToInt32(propertyDescriptor.GetValue(configOptions));
+                                indentSize = Convert.ToInt32(propertyDescriptor.GetValue(configOptions), CultureInfo.InvariantCulture);
                             }
                             catch (Exception)
                             {

--- a/XamlStyler.Core/Options/StylerOptions.cs
+++ b/XamlStyler.Core/Options/StylerOptions.cs
@@ -155,6 +155,7 @@ namespace Xavalon.XamlStyler.Core.Options
             "Storyboard.*, From, To, Duration",
         })]
         [TypeConverter(typeof(StringArrayConverter))]
+        [SuppressMessage("Performance", "CA1819:Properties should not return arrays", Justification = "Required for serialization/deserialization")]
         public string[] AttributeOrderingRuleGroups { get; set; }
 
         [Category("Attribute Reordering")]

--- a/XamlStyler.Core/Parser/ContentTypeEnum.cs
+++ b/XamlStyler.Core/Parser/ContentTypeEnum.cs
@@ -5,7 +5,7 @@ using System;
 namespace Xavalon.XamlStyler.Core.Parser
 {
     [Flags]
-    public enum ContentTypeEnum
+    public enum ContentTypes
     {
         None = 0,
         SingleLineTextOnly = 1,

--- a/XamlStyler.Core/Parser/ElementProcessStatus.cs
+++ b/XamlStyler.Core/Parser/ElementProcessStatus.cs
@@ -11,7 +11,7 @@ namespace Xavalon.XamlStyler.Core.Parser
         ///     <Element>asdf<OtherElements/></Element> ContentTypeEnum.TEXT_ONLY
         ///     <Element>asdf<OtherElements/></Element> ContentTypeEnum.MIXED
         /// </summary>
-        public ContentTypeEnum ContentType { get; set; }
+        public ContentTypes ContentType { get; set; }
 
         /// <summary>
         /// Gets or sets whether the start tag of this element has been broken into multi-lines.

--- a/XamlStyler.Core/Services/IndentService.cs
+++ b/XamlStyler.Core/Services/IndentService.cs
@@ -54,7 +54,7 @@ namespace Xavalon.XamlStyler.Core.Services
                     case AttributeIndentationStyle.Spaces:
                         return new String('\t', depth) + new String(' ', additionalSpaces);
                     default:
-                        throw new ArgumentOutOfRangeException();
+                        throw new NotImplementedException();
                 }
 
             }

--- a/XamlStyler.Core/XamlStyler.Core.csproj
+++ b/XamlStyler.Core/XamlStyler.Core.csproj
@@ -20,6 +20,10 @@
     <PackageReference Include="Irony">
       <Version>1.1.0</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>9.0.1</Version>
     </PackageReference>

--- a/XamlStyler.Package/Properties/AssemblyInfo.cs
+++ b/XamlStyler.Package/Properties/AssemblyInfo.cs
@@ -30,3 +30,4 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: NeutralResourcesLanguage("en")]

--- a/XamlStyler.Package/XamlStyler.Package.csproj
+++ b/XamlStyler.Package/XamlStyler.Package.csproj
@@ -31,6 +31,7 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -43,6 +44,7 @@
     <StartAction>Program</StartAction>
     <StartProgram>$(DevEnvDir)\devenv.exe</StartProgram>
     <StartArguments>/rootsuffix Exp</StartArguments>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -52,6 +54,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DeployExtension>false</DeployExtension>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Guids.cs" />

--- a/XamlStyler.Package/XamlStyler.Package.csproj
+++ b/XamlStyler.Package/XamlStyler.Package.csproj
@@ -51,7 +51,6 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
     <DeployExtension>false</DeployExtension>
   </PropertyGroup>
   <ItemGroup>

--- a/XamlStyler.Package/XamlStyler.Package.csproj
+++ b/XamlStyler.Package/XamlStyler.Package.csproj
@@ -125,6 +125,11 @@
     <PackageReference Include="EnvDTE">
       <Version>8.0.2</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers">
+      <Version>2.6.3</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Imaging">
       <Version>15.0.26201</Version>
     </PackageReference>

--- a/XamlStyler.UnitTests/FileHandlingIntegrationTests.cs
+++ b/XamlStyler.UnitTests/FileHandlingIntegrationTests.cs
@@ -450,12 +450,6 @@ namespace Xavalon.XamlStyler.UnitTests
             FileHandlingIntegrationTests.DoTest(stylerOptions);
         }
 
-        private void DoTest([System.Runtime.CompilerServices.CallerMemberName] string callerMemberName = "")
-        {
-            // ReSharper disable once ExplicitCallerInfoArgument
-            FileHandlingIntegrationTests.DoTest(new StylerOptions(), callerMemberName);
-        }
-
         private static void DoTest(
             StylerOptions stylerOptions,
             [System.Runtime.CompilerServices.CallerMemberName] string callerMemberName = "")

--- a/XamlStyler.UnitTests/FileHandlingIntegrationTests.cs
+++ b/XamlStyler.UnitTests/FileHandlingIntegrationTests.cs
@@ -19,7 +19,7 @@ namespace Xavalon.XamlStyler.UnitTests
         public void TestAttributeIndentationHandling(byte attributeIndentation)
         {
             var stylerOptions = new StylerOptions(
-                config: this.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
+                config: FileHandlingIntegrationTests.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
             {
                 AttributeIndentation = attributeIndentation,
                 AttributesTolerance = 0,
@@ -35,19 +35,19 @@ namespace Xavalon.XamlStyler.UnitTests
         public void TestDesignReferenceRemoval()
         {
             var stylerOptions = new StylerOptions(
-                config: this.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
+                config: FileHandlingIntegrationTests.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
             {
                 RemoveDesignTimeReferences = true
             };
 
-            this.DoTest(stylerOptions);
+            FileHandlingIntegrationTests.DoTest(stylerOptions);
         }
 
         [Test]
         public void TestAttributeThresholdHandling()
         {
             var stylerOptions = new StylerOptions(
-                config: this.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
+                config: FileHandlingIntegrationTests.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
             {
                 AttributesTolerance = 0,
                 MaxAttributeCharactersPerLine = 80,
@@ -55,20 +55,20 @@ namespace Xavalon.XamlStyler.UnitTests
                 PutEndingBracketOnNewLine = true
             };
 
-            this.DoTest(stylerOptions);
+            FileHandlingIntegrationTests.DoTest(stylerOptions);
         }
 
         [Test]
         public void TestAttributeToleranceHandling()
         {
             var stylerOptions = new StylerOptions(
-                config: this.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
+                config: FileHandlingIntegrationTests.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
             {
                 AttributesTolerance = 3,
                 RootElementLineBreakRule = LineBreakRule.Always,
             };
 
-            this.DoTest(stylerOptions);
+            FileHandlingIntegrationTests.DoTest(stylerOptions);
         }
 
         [TestCase(0)]
@@ -90,32 +90,32 @@ namespace Xavalon.XamlStyler.UnitTests
         [Test]
         public void TestCommentAtFirstLine()
         {
-            this.DoTest(this.GetLegacyStylerOptions());
+            FileHandlingIntegrationTests.DoTest(this.GetLegacyStylerOptions());
         }
 
         [Test]
         public void TestDefaultHandling()
         {
-            this.DoTest(this.GetLegacyStylerOptions());
+            FileHandlingIntegrationTests.DoTest(this.GetLegacyStylerOptions());
         }
 
         [Test]
         public void TestSuppressedDefaultHandling()
         {
             var stylerOptions = new StylerOptions(
-                config: this.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
+                config: FileHandlingIntegrationTests.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
             {
                 SuppressProcessing = true
             };
 
-            this.DoTest(stylerOptions);
+            FileHandlingIntegrationTests.DoTest(stylerOptions);
         }
 
         [Test]
         public void TestAttributeSortingOptionHandling()
         {
             var stylerOptions = new StylerOptions(
-                config: this.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
+                config: FileHandlingIntegrationTests.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
             {
                 AttributeOrderingRuleGroups = new[]
                 {
@@ -144,31 +144,31 @@ namespace Xavalon.XamlStyler.UnitTests
                 }
             };
 
-            this.DoTest(stylerOptions);
+            FileHandlingIntegrationTests.DoTest(stylerOptions);
         }
 
         [Test]
         public void TestxBindSplitting()
         {
             var stylerOptions = new StylerOptions(
-                config: this.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
+                config: FileHandlingIntegrationTests.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
             {
                 NoNewLineMarkupExtensions = "x:Bind"
             };
 
-            this.DoTest(stylerOptions);
+            FileHandlingIntegrationTests.DoTest(stylerOptions);
         }
 
         [Test]
         public void TestBindingSplitting()
         {
             var stylerOptions = new StylerOptions(
-                config: this.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
+                config: FileHandlingIntegrationTests.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
             {
                 NoNewLineMarkupExtensions = "x:Bind, Binding"
             };
 
-            this.DoTest(stylerOptions);
+            FileHandlingIntegrationTests.DoTest(stylerOptions);
         }
 
         [TestCase(false, 2)]
@@ -178,7 +178,7 @@ namespace Xavalon.XamlStyler.UnitTests
         public void TestMarkupExtensionHandling(bool indentWithTabs, int tabSize)
         {
             var stylerOptions = new StylerOptions(
-                config: this.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
+                config: FileHandlingIntegrationTests.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
             {
                 FormatMarkupExtension = true,
                 IndentWithTabs = indentWithTabs,
@@ -193,20 +193,20 @@ namespace Xavalon.XamlStyler.UnitTests
         public void TestNestedCustomMarkupExtensionsWithBindings()
         {
             var stylerOptions = new StylerOptions(
-                config: this.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
+                config: FileHandlingIntegrationTests.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
             {
                 KeepFirstAttributeOnSameLine = false,
                 AttributesTolerance = 1,
                 NoNewLineMarkupExtensions = "x:Bind, Binding"
             };
 
-            this.DoTest(stylerOptions);
+            FileHandlingIntegrationTests.DoTest(stylerOptions);
         }
 
         [Test]
         public void TestSingleLineNestedMarkupExtensions()
         {
-            this.DoTest(new StylerOptions
+            FileHandlingIntegrationTests.DoTest(new StylerOptions
             {
                 IndentSize = 2
             });
@@ -216,98 +216,98 @@ namespace Xavalon.XamlStyler.UnitTests
         public void TestMarkupWithAttributeNotOnFirstLine()
         {
             var stylerOptions = new StylerOptions(
-                config: this.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
+                config: FileHandlingIntegrationTests.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
             {
                 KeepFirstAttributeOnSameLine = false,
                 AttributesTolerance = 1
             };
 
-            this.DoTest(stylerOptions);
+            FileHandlingIntegrationTests.DoTest(stylerOptions);
         }
 
         [Test]
         public void TestNoContentElementHandling()
         {
-            this.DoTest(this.GetLegacyStylerOptions());
+            FileHandlingIntegrationTests.DoTest(this.GetLegacyStylerOptions());
         }
 
         [Test]
         public void TestTextOnlyContentElementHandling()
         {
-            this.DoTest(this.GetLegacyStylerOptions());
+            FileHandlingIntegrationTests.DoTest(this.GetLegacyStylerOptions());
         }
 
         [Test]
         public void TestGridChildrenHandling()
         {
-            this.DoTest(this.GetLegacyStylerOptions());
+            FileHandlingIntegrationTests.DoTest(this.GetLegacyStylerOptions());
         }
 
         [Test]
         public void TestNestedGridChildrenHandling()
         {
-            this.DoTest(this.GetLegacyStylerOptions());
+            FileHandlingIntegrationTests.DoTest(this.GetLegacyStylerOptions());
         }
 
         [Test]
         public void TestCanvasChildrenHandling()
         {
-            this.DoTest(this.GetLegacyStylerOptions());
+            FileHandlingIntegrationTests.DoTest(this.GetLegacyStylerOptions());
         }
 
         [Test]
         public void TestNestedCanvasChildrenHandling()
         {
-            this.DoTest(this.GetLegacyStylerOptions());
+            FileHandlingIntegrationTests.DoTest(this.GetLegacyStylerOptions());
         }
 
         [Test]
         public void TestNestedPropertiesAndChildrenHandling()
         {
             var stylerOptions = new StylerOptions(
-                config: this.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
+                config: FileHandlingIntegrationTests.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
             {
                 ReorderVSM = VisualStateManagerRule.First
             };
 
-            this.DoTest(stylerOptions);
+            FileHandlingIntegrationTests.DoTest(stylerOptions);
         }
 
         [Test]
         public void TestKeepSelectAttributesOnFirstLine()
         {
             var stylerOptions = new StylerOptions(
-                config: this.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
+                config: FileHandlingIntegrationTests.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
             {
                 FirstLineAttributes = "x:Name, x:Key"
             };
 
-            this.DoTest(stylerOptions);
+            FileHandlingIntegrationTests.DoTest(stylerOptions);
         }
 
         [Test]
         public void TestAttributeOrderRuleGroupsOnSeparateLinesHandling()
         {
             var stylerOptions = new StylerOptions(
-                config: this.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
+                config: FileHandlingIntegrationTests.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
             {
                 PutAttributeOrderRuleGroupsOnSeparateLines = true,
                 MaxAttributesPerLine = 3,
             };
 
-            this.DoTest(stylerOptions);
+            FileHandlingIntegrationTests.DoTest(stylerOptions);
         }
 
         [Test]
         public void TestProcessingInstructionHandling()
         {
-            this.DoTest(this.GetLegacyStylerOptions());
+            FileHandlingIntegrationTests.DoTest(this.GetLegacyStylerOptions());
         }
 
         [Test]
         public void TestXmlnsAliasesHandling()
         {
-            this.DoTest(this.GetLegacyStylerOptions());
+            FileHandlingIntegrationTests.DoTest(this.GetLegacyStylerOptions());
         }
 
         [TestCase(ReorderSettersBy.Property)]
@@ -316,7 +316,7 @@ namespace Xavalon.XamlStyler.UnitTests
         public void TestReorderSetterHandling(ReorderSettersBy reorderSettersBy)
         {
             var stylerOptions = new StylerOptions(
-                config: this.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
+                config: FileHandlingIntegrationTests.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
             {
                 ReorderSetters = reorderSettersBy,
             };
@@ -329,7 +329,7 @@ namespace Xavalon.XamlStyler.UnitTests
         public void TestClosingElementHandling(int testNumber, bool spaceBeforeClosingSlash)
         {
             var stylerOptions = new StylerOptions(
-                config: this.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
+                config: FileHandlingIntegrationTests.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
             {
                 SpaceBeforeClosingSlash = spaceBeforeClosingSlash
             };
@@ -340,13 +340,13 @@ namespace Xavalon.XamlStyler.UnitTests
         [Test]
         public void TestCDATAHandling()
         {
-            this.DoTest(this.GetLegacyStylerOptions());
+            FileHandlingIntegrationTests.DoTest(this.GetLegacyStylerOptions());
         }
 
         [Test]
         public void TestXmlSpaceHandling()
         {
-            this.DoTest(this.GetLegacyStylerOptions());
+            FileHandlingIntegrationTests.DoTest(this.GetLegacyStylerOptions());
         }
 
         [TestCase(ThicknessStyle.None)]
@@ -355,7 +355,7 @@ namespace Xavalon.XamlStyler.UnitTests
         public void TestThicknessHandling(ThicknessStyle thicknessStyle)
         {
             var stylerOptions = new StylerOptions(
-                config: this.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
+                config: FileHandlingIntegrationTests.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
             {
                 ThicknessStyle = thicknessStyle
             };
@@ -369,7 +369,7 @@ namespace Xavalon.XamlStyler.UnitTests
         public void TestRootHandling(int testNumber, LineBreakRule lineBreakRule)
         {
             var stylerOptions = new StylerOptions(
-                config: this.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
+                config: FileHandlingIntegrationTests.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
             {
                 AttributesTolerance = 3,
                 MaxAttributesPerLine = 4,
@@ -383,14 +383,14 @@ namespace Xavalon.XamlStyler.UnitTests
         [Test]
         public void TestRunHandling()
         {
-            this.DoTest(this.GetLegacyStylerOptions());
+            FileHandlingIntegrationTests.DoTest(this.GetLegacyStylerOptions());
         }
 
         [Test]
         public void TestWildCard()
         {
             var stylerOptions = new StylerOptions(
-                config: this.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
+                config: FileHandlingIntegrationTests.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
             {
                 AttributeOrderingRuleGroups = new[]
                 {
@@ -405,58 +405,58 @@ namespace Xavalon.XamlStyler.UnitTests
                 }
             };
 
-            this.DoTest(stylerOptions);
+            FileHandlingIntegrationTests.DoTest(stylerOptions);
         }
 
         [Test]
         public void TestValueXmlEntityHandling()
         {
-            this.DoTest(this.GetLegacyStylerOptions());
+            FileHandlingIntegrationTests.DoTest(this.GetLegacyStylerOptions());
         }
 
         [Test]
         public void TestVisualStateManagerNone()
         {
             var stylerOptions = new StylerOptions(
-                config: this.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
+                config: FileHandlingIntegrationTests.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
             {
                 ReorderVSM = VisualStateManagerRule.None
             };
 
-            this.DoTest(stylerOptions);
+            FileHandlingIntegrationTests.DoTest(stylerOptions);
         }
 
         [Test]
         public void TestVisualStateManagerFirst()
         {
             var stylerOptions = new StylerOptions(
-                config: this.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
+                config: FileHandlingIntegrationTests.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
             {
                 ReorderVSM = VisualStateManagerRule.First
             };
 
-            this.DoTest(stylerOptions);
+            FileHandlingIntegrationTests.DoTest(stylerOptions);
         }
 
         [Test]
         public void TestVisualStateManagerLast()
         {
             var stylerOptions = new StylerOptions(
-                config: this.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
+                config: FileHandlingIntegrationTests.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"))
             {
                 ReorderVSM = VisualStateManagerRule.Last
             };
 
-            this.DoTest(stylerOptions);
+            FileHandlingIntegrationTests.DoTest(stylerOptions);
         }
 
         private void DoTest([System.Runtime.CompilerServices.CallerMemberName] string callerMemberName = "")
         {
             // ReSharper disable once ExplicitCallerInfoArgument
-            this.DoTest(new StylerOptions(), callerMemberName);
+            FileHandlingIntegrationTests.DoTest(new StylerOptions(), callerMemberName);
         }
 
-        private void DoTest(
+        private static void DoTest(
             StylerOptions stylerOptions,
             [System.Runtime.CompilerServices.CallerMemberName] string callerMemberName = "")
         {
@@ -501,7 +501,7 @@ namespace Xavalon.XamlStyler.UnitTests
             Assert.That(actualOutput, Is.EqualTo(File.ReadAllText($"{testFileResultBaseName}.expected")));
         }
 
-        private string GetConfiguration(string path)
+        private static string GetConfiguration(string path)
         {
             return Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), path);
         }
@@ -509,7 +509,7 @@ namespace Xavalon.XamlStyler.UnitTests
         private StylerOptions GetLegacyStylerOptions()
         {
             return new StylerOptions(
-                config: this.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"));
+                config: FileHandlingIntegrationTests.GetConfiguration(@"TestConfigurations\LegacyTestSettings.json"));
         }
     }
 }

--- a/XamlStyler.UnitTests/MarkupExtensions/MarkupExtensionParserObjectGraphUnitTests.cs
+++ b/XamlStyler.UnitTests/MarkupExtensions/MarkupExtensionParserObjectGraphUnitTests.cs
@@ -60,7 +60,7 @@ namespace Xavalon.XamlStyler.UnitTests.MarkupExtensions
         }
 
         [Test]
-        public void TestHelloworldFoo1Bar42_spaced()
+        public void TestHelloworldFoo1Bar42Spaced()
         {
             var sourceText = "  {  Hello   world ,  foo  =  1  ,  bar = 42  }  ";
             var expected = new MarkupExtension(

--- a/XamlStyler.UnitTests/TestConfigurations.cs
+++ b/XamlStyler.UnitTests/TestConfigurations.cs
@@ -13,7 +13,7 @@ namespace Xavalon.XamlStyler.UnitTests
     //test runner (probably ReSharper, it searches for the config files in the wrong directory)
 
     [TestFixture]
-    public sealed partial class UnitTests
+    public sealed partial class Tests
     {
         [Test]
         public void TestConfigurationDefault()

--- a/XamlStyler.UnitTests/TestConfigurations.cs
+++ b/XamlStyler.UnitTests/TestConfigurations.cs
@@ -16,35 +16,35 @@ namespace Xavalon.XamlStyler.UnitTests
     public sealed partial class UnitTests
     {
         [Test]
-        public void TestConfiguration_Default()
+        public void TestConfigurationDefault()
         {
             var stylerOptions = new StylerOptions(config: this.GetConfiguration(@"TestConfigurations\Default.json"));
             this.TestConfig(stylerOptions, @"TestConfigurations\SerializedDefault.json");
         }
 
         [Test]
-        public void TestConfiguration_Empty()
+        public void TestConfigurationEmpty()
         {
             var stylerOptions = new StylerOptions(config: this.GetConfiguration(@"TestConfigurations\Empty.json"));
             this.TestConfig(stylerOptions, @"TestConfigurations\SerializedDefault.json");
         }
 
         [Test]
-        public void TestConfiguration_Single()
+        public void TestConfigurationSingle()
         {
             var stylerOptions = new StylerOptions(config: this.GetConfiguration(@"TestConfigurations\Single.json"));
             this.TestConfig(stylerOptions, @"TestConfigurations\Single.json");
         }
 
         [Test]
-        public void TestConfiguration_BadSetting()
+        public void TestConfigurationBadSetting()
         {
             var stylerOptions = new StylerOptions(config: this.GetConfiguration(@"TestConfigurations\BadSetting.json"));
             this.TestConfig(stylerOptions, @"TestConfigurations\SerializedDefault.json");
         }
 
         [Test]
-        public void TestConfiguration_AllDifferent()
+        public void TestConfigurationAllDifferent()
         {
             var stylerOptions = new StylerOptions(config: this.GetConfiguration(@"TestConfigurations\AllDifferent.json"));
             this.TestConfig(stylerOptions, @"TestConfigurations\AllDifferent.json");

--- a/XamlStyler.UnitTests/TestConfigurations.cs
+++ b/XamlStyler.UnitTests/TestConfigurations.cs
@@ -18,47 +18,47 @@ namespace Xavalon.XamlStyler.UnitTests
         [Test]
         public void TestConfigurationDefault()
         {
-            var stylerOptions = new StylerOptions(config: this.GetConfiguration(@"TestConfigurations\Default.json"));
+            var stylerOptions = new StylerOptions(config: Tests.GetConfiguration(@"TestConfigurations\Default.json"));
             this.TestConfig(stylerOptions, @"TestConfigurations\SerializedDefault.json");
         }
 
         [Test]
         public void TestConfigurationEmpty()
         {
-            var stylerOptions = new StylerOptions(config: this.GetConfiguration(@"TestConfigurations\Empty.json"));
+            var stylerOptions = new StylerOptions(config: Tests.GetConfiguration(@"TestConfigurations\Empty.json"));
             this.TestConfig(stylerOptions, @"TestConfigurations\SerializedDefault.json");
         }
 
         [Test]
         public void TestConfigurationSingle()
         {
-            var stylerOptions = new StylerOptions(config: this.GetConfiguration(@"TestConfigurations\Single.json"));
+            var stylerOptions = new StylerOptions(config: Tests.GetConfiguration(@"TestConfigurations\Single.json"));
             this.TestConfig(stylerOptions, @"TestConfigurations\Single.json");
         }
 
         [Test]
         public void TestConfigurationBadSetting()
         {
-            var stylerOptions = new StylerOptions(config: this.GetConfiguration(@"TestConfigurations\BadSetting.json"));
+            var stylerOptions = new StylerOptions(config: Tests.GetConfiguration(@"TestConfigurations\BadSetting.json"));
             this.TestConfig(stylerOptions, @"TestConfigurations\SerializedDefault.json");
         }
 
         [Test]
         public void TestConfigurationAllDifferent()
         {
-            var stylerOptions = new StylerOptions(config: this.GetConfiguration(@"TestConfigurations\AllDifferent.json"));
+            var stylerOptions = new StylerOptions(config: Tests.GetConfiguration(@"TestConfigurations\AllDifferent.json"));
             this.TestConfig(stylerOptions, @"TestConfigurations\AllDifferent.json");
         }
 
         private void TestConfig(StylerOptions stylerOptions, string expectedConfiguration)
         {
             var actualOptions = JsonConvert.SerializeObject(stylerOptions);
-            var expectedOptions = File.ReadAllText(this.GetConfiguration(expectedConfiguration));
+            var expectedOptions = File.ReadAllText(Tests.GetConfiguration(expectedConfiguration));
 
             Assert.That(Regex.Replace(actualOptions, @"\s+", ""), Is.EqualTo(Regex.Replace(expectedOptions, @"\s+", "")));
         }
 
-        private string GetConfiguration(string path)
+        private static string GetConfiguration(string path)
         {
             return Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), path);
         }

--- a/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
+++ b/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
@@ -11,6 +11,10 @@
     </PackageReference>
     <PackageReference Include="Irony" Version="1.1.0">
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1">
     </PackageReference>


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->

### Description:

Fixes #230

This change migrate solution from legacy analysis (FxCop) to source analysis (FxCop analyzers). All warnings have been addressed as part of this change.

### Checklist:
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] I have tested my changes by running the extension in VS2017
* [x] I have tested my changes by running the extension in VS2019
* [ ] If changes to the [documentation](https://github.com/Xavalon/XamlStyler/wiki) are needed, I have noted this in the description above
