### PR TITLE
Reset patch version number monthly

### DIFF
--- a/build/pipelines/azure-pipelines.ci.yml
+++ b/build/pipelines/azure-pipelines.ci.yml
@@ -11,7 +11,7 @@ pr:
 variables:
   buildConfiguration: 'Release'
   major: 0
-  patch: $[counter(format('{0:yyyyMMdd}', pipeline.startTime), 0)]
+  patch: $[counter(format('{0:yyMM}', pipeline.startTime), 0)]
 
 name: $(major).$(Date:yyMM).$(patch).0
 

--- a/build/pipelines/azure-pipelines.release.yml
+++ b/build/pipelines/azure-pipelines.release.yml
@@ -11,7 +11,7 @@ pr: none
 variables:
   buildConfiguration: 'Release'
   major: 3
-  patch: $[counter(format('{0:yyyyMMdd}', pipeline.startTime), 0)]
+  patch: $[counter(format('{0:yyMM}', pipeline.startTime), 0)]
 
 name: $(major).$(Date:yyMM).$(patch).0
 


### PR DESCRIPTION
### Description:

This change addresses an issue with build numbers are being reset daily instead of monthly with minor version bumps.

A side effect of this change is that 3.2001.* builds will reset to 3.2001.0. We can address any versioning conflicts this month as necessary, but it is unlikely we will ship another version of 3.2001.*.