### PR TITLE
Add support for configuring IndentWithTabs via external config in CLI

### DIFF
--- a/XamlStyler.Core/Options/IStylerOptions.cs
+++ b/XamlStyler.Core/Options/IStylerOptions.cs
@@ -16,7 +16,9 @@ namespace Xavalon.XamlStyler.Core.Options
 
         bool UseVisualStudioIndentSize { get; }
 
-        bool IndentWithTabs { get; set; }
+        bool? IndentWithTabs { get; set; }
+
+        bool UseVisualStudioIndentWithTabs { get; }
 
         #endregion Indentation
 

--- a/XamlStyler.Core/Options/StylerOptions.cs
+++ b/XamlStyler.Core/Options/StylerOptions.cs
@@ -58,10 +58,16 @@ namespace Xavalon.XamlStyler.Core.Options
         public bool UseVisualStudioIndentSize { get; private set; } = true;
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        [DefaultValue(false)]
+        [DefaultValue(null)]
+        [JsonProperty("IndentWithTabs", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [Browsable(false)]
+        public bool? IndentWithTabs { get; set; }
+
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [DefaultValue(true)]
         [Browsable(false)]
         [JsonIgnore]
-        public bool IndentWithTabs { get; set; }
+        public bool UseVisualStudioIndentWithTabs { get; private set; } = true;
 
         // Attribute formatting
         [Category("Attribute Formatting")]
@@ -414,6 +420,31 @@ namespace Xavalon.XamlStyler.Core.Options
                             else
                             {
                                 this.IndentSize = StylerOptions.FallbackIndentSize;
+                            }
+                        }
+                        // If a valid IndentWithTabs is specified in configuration, do not load VS settings.
+                        // If it is unspecified, it will be null.
+                        else if (propertyDescriptor.Name.Equals(nameof(this.IndentWithTabs), StringComparison.Ordinal) &&
+                            propertyDescriptor.GetValue(configOptions) != null)
+                        {
+                            bool? indentWithTabs;
+                            try
+                            {
+                                indentWithTabs = Convert.ToBoolean(propertyDescriptor.GetValue(configOptions), CultureInfo.InvariantCulture);
+                            }
+                            catch (Exception)
+                            {
+                                indentWithTabs = null;
+                            }
+
+                            if (indentWithTabs == true)
+                            {
+                                this.IndentWithTabs = true;
+                                this.UseVisualStudioIndentWithTabs = false;
+                            }
+                            else
+                            {
+                                this.IndentWithTabs = indentWithTabs;
                             }
                         }
                         else

--- a/XamlStyler.Core/Services/IndentService.cs
+++ b/XamlStyler.Core/Services/IndentService.cs
@@ -13,7 +13,7 @@ namespace Xavalon.XamlStyler.Core.Services
 
         public IndentService(IStylerOptions options)
         {
-            this.indentWithTabs = options.IndentWithTabs;
+            this.indentWithTabs = options.IndentWithTabs ?? false;
             this.indentSize = options.IndentSize;
             this.attributeIndentationStyle = options.AttributeIndentationStyle;
         }

--- a/XamlStyler.Package/StylerPackage.cs
+++ b/XamlStyler.Package/StylerPackage.cs
@@ -235,7 +235,10 @@ namespace Xavalon.XamlStyler.Package
                 }
             }
 
-            stylerOptions.IndentWithTabs = (bool)xamlEditorProps.Item("InsertTabs").Value;
+            if (stylerOptions.UseVisualStudioIndentWithTabs)
+            {
+                stylerOptions.IndentWithTabs = (bool)xamlEditorProps.Item("InsertTabs").Value;
+            }
 
             return stylerOptions;
         }

--- a/XamlStyler.UnitTests/TestConfigurations.cs
+++ b/XamlStyler.UnitTests/TestConfigurations.cs
@@ -20,6 +20,8 @@ namespace Xavalon.XamlStyler.UnitTests
         {
             var stylerOptions = new StylerOptions(config: Tests.GetConfiguration(@"TestConfigurations\Default.json"));
             this.TestConfig(stylerOptions, @"TestConfigurations\SerializedDefault.json");
+
+            Assert.IsTrue(stylerOptions.UseVisualStudioIndentWithTabs);
         }
 
         [Test]
@@ -48,6 +50,16 @@ namespace Xavalon.XamlStyler.UnitTests
         {
             var stylerOptions = new StylerOptions(config: Tests.GetConfiguration(@"TestConfigurations\AllDifferent.json"));
             this.TestConfig(stylerOptions, @"TestConfigurations\AllDifferent.json");
+        }
+
+        [Test]
+        public void TestConfigurationIndentUsingTabs()
+        {
+            var stylerOptions = new StylerOptions(config: Tests.GetConfiguration(@"TestConfigurations\IndentWithTabsOverride.json"));
+            this.TestConfig(stylerOptions, @"TestConfigurations\IndentWithTabsOverride.json");
+
+            Assert.IsFalse(stylerOptions.UseVisualStudioIndentWithTabs); // IndentWithTabs is true
+            Assert.IsFalse(stylerOptions.UseVisualStudioIndentSize); // IndentSize is set
         }
 
         private void TestConfig(StylerOptions stylerOptions, string expectedConfiguration)

--- a/XamlStyler.UnitTests/TestConfigurations/IndentWithTabsOverride.json
+++ b/XamlStyler.UnitTests/TestConfigurations/IndentWithTabsOverride.json
@@ -1,0 +1,5 @@
+{
+    "IndentSize": 4,
+    "IndentWithTabs": true,
+    "AttributesTolerance": 3
+}

--- a/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
+++ b/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
@@ -50,6 +50,9 @@
   <None Update="TestConfigurations\SerializedDefault.json">
     <CopyToOutputDirectory>Always</CopyToOutputDirectory>
   </None>
+  <None Update="TestConfigurations\IndentWithTabsOverride.json">
+    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+  </None>
   <None Update="TestConfigurations\Single.json">
     <CopyToOutputDirectory>Always</CopyToOutputDirectory>
   </None>


### PR DESCRIPTION
### Description:

Fixes #195 

`IndentWithTabs` was not meant to be configurable, but it makes it impossible to use tabs using the CLI / console

I tried to follow the suggestions from this [comment](https://github.com/Xavalon/XamlStyler/issues/195#issuecomment-515243163) from @grochocki 

Added a new property `UseVisualStudioIndentWithTabs` to maintain support for existing configurations. 

`IndentWithSpaces` is now a _nullable<bool>_ with default value of null to be able to determine if the property is present in the configuration or not. 

#### Documentation update:
We should add a note here : https://github.com/Xavalon/XamlStyler/wiki/External-Configurations#indent-size

Suggestion:
```
IndentWithSpaces
XAML Styler (plugin only) detects and uses Visual Studio insertTabs setting by default. However, since xstyler.exe runs independently of Visual Studio, we are unable to detect those options. If you want to override the default behavior for either the plugin or xstyler.exe, you can set an extra property "IndentWithTabs" in an external configuration.

Default Value (plugin): Visual Studio options
Default Value (xstyler.exe): null (which is false)

Example:

"IndentWithTabs": true
```

### Checklist:
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] I have tested my changes by running the extension in VS2017
* [x] I have tested my changes by running the extension in VS2019
* [x] If changes to the [documentation](https://github.com/Xavalon/XamlStyler/wiki) are needed, I have noted this in the description above
