### PR TITLE
Add passive check option to CLI

### DIFF
--- a/XamlStyler.Console/Options.cs
+++ b/XamlStyler.Console/Options.cs
@@ -25,6 +25,9 @@ namespace Xavalon.XamlStyler.Xmagic
         [Option('r', "recursive", Default = false, HelpText = "Recursively process specified directory.")]
         public bool IsRecursive { get; set; }
 
+        [Option('p', "passive", Default = false, HelpText = "Check files follow proper formatting without making any modifications.")]
+        public bool IsPassive { get; set; }
+
         [Option('l', "loglevel", Default = LogLevel.Default,
             HelpText = "Levels in order of increasing detail: None, Minimal, Default, Verbose, Debug")]
         public LogLevel LogLevel { get; set; }

--- a/XamlStyler.Console/Program.cs
+++ b/XamlStyler.Console/Program.cs
@@ -12,7 +12,7 @@ namespace Xavalon.XamlStyler.Xmagic
         {
             var writer = new StringWriter();
             var parser = new Parser(_ => _.HelpWriter = writer);
-            var result = parser.ParseArguments<CommandLineOptions>(args);
+            ParserResult<CommandLineOptions> result = parser.ParseArguments<CommandLineOptions>(args);
 
             result.WithNotParsed(_ =>
             {
@@ -28,7 +28,7 @@ namespace Xavalon.XamlStyler.Xmagic
                     Console.WriteLine($"File Directory: '{options.Directory}'");
                 }
 
-                bool isFileOptionSpecified = ((options.File?.Count ?? 0) != 0);
+                bool isFileOptionSpecified = (options.File?.Count ?? 0) != 0;
                 bool isDirectoryOptionSpecified = !String.IsNullOrEmpty(options.Directory);
 
                 if (isFileOptionSpecified ^ isDirectoryOptionSpecified)
@@ -38,7 +38,7 @@ namespace Xavalon.XamlStyler.Xmagic
                 }
                 else
                 {
-                    var errorString = (isFileOptionSpecified && isDirectoryOptionSpecified)
+                    string errorString = (isFileOptionSpecified && isDirectoryOptionSpecified)
                         ? "Cannot specify both file(s) and directory"
                         : "Must specify file(s) or directory";
 


### PR DESCRIPTION
### Description:

Adds option to CLI to check files without formatting. Errors on format check failure. Documentation should be updated to match option description in this change.

Fixes #176

<!-- Please include a summary of your changes. Provide enough information so that others can review your pull request. -->

### Checklist:
* [X] I have commented my code, particularly in hard-to-understand areas
* [X] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [X] New and existing unit tests pass locally with my changes
* [ ] I have tested my changes by running the extension in VS2017
* [ ] I have tested my changes by running the extension in VS2019
* [X] If changes to the [documentation](https://github.com/Xavalon/XamlStyler/wiki) are needed, I have noted this in the description above
