### PR TITLE
Address (some) non-fatal warnings and errors in Rider build pipeline #296

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ XAML Styler is a visual studio extension that formats XAML source code based on 
 ## Downloads
 [![VS2019](https://img.shields.io/visual-studio-marketplace/v/TeamXavalon.XAMLStyler.svg?label=Visual%20Studio%202019)](https://marketplace.visualstudio.com/items?itemName=TeamXavalon.XAMLStyler)
 
-[![VS2017](https://img.shields.io/visual-studio-marketplace/v/TeamXavalon.XAMLStyler.svg?label=Visual%20Studio%202017)](https://marketplace.visualstudio.com/items?itemName=TeamXavalon.XAMLStyler)
-
 [![VSMAC](https://img.shields.io/badge/Visual%20Studio%20for%20Mac%202019-v2.0.1-blue.svg)](http://addins.monodevelop.com/Project/Index/382)
+
+![JetBrains IntelliJ Plugins](https://img.shields.io/jetbrains/plugin/v/14932-xaml-styler?label=JetBrains%20Rider)
 
 [![NuGet](https://img.shields.io/nuget/v/XamlStyler.Console.svg?label=XAML%20Styler%20Console)](https://www.nuget.org/packages/XamlStyler.Console)  
 <sub>View [other downloads](https://github.com/Xavalon/XamlStyler/wiki)</sub>

--- a/src/XamlStyler.Extension.Rider/rider/main/kotlin/xavalon/plugins/xamlstyler/rider/XamlStylerComponent.kt
+++ b/src/XamlStyler.Extension.Rider/rider/main/kotlin/xavalon/plugins/xamlstyler/rider/XamlStylerComponent.kt
@@ -7,18 +7,19 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.fileEditor.FileDocumentManagerListener
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
+import com.jetbrains.rd.platform.util.getComponent
+import com.jetbrains.rd.platform.util.idea.ProtocolSubscribedProjectComponent
 import com.jetbrains.rd.util.reactive.adviseOnce
-import com.jetbrains.rdclient.util.idea.ProtocolSubscribedProjectComponent
 import com.jetbrains.rider.ideaInterop.fileTypes.xaml.XamlLanguage
 import com.jetbrains.rider.model.RdXamlStylerFormattingRequest
 import com.jetbrains.rider.model.xamlStylerModel
 import com.jetbrains.rider.projectView.solution
-import com.jetbrains.rider.util.idea.getComponent
 
 class XamlStylerComponent(project: Project)
     : ProtocolSubscribedProjectComponent(project), FileDocumentManagerListener {
 
     companion object {
+        @Suppress("unused")
         fun getInstance(project: Project) = project.getComponent<XamlStylerComponent>()
     }
 

--- a/src/XamlStyler.Extension.Rider/rider/main/kotlin/xavalon/plugins/xamlstyler/rider/XamlStylerComponent.kt
+++ b/src/XamlStyler.Extension.Rider/rider/main/kotlin/xavalon/plugins/xamlstyler/rider/XamlStylerComponent.kt
@@ -43,8 +43,8 @@ class XamlStylerComponent(project: Project)
         val currentDocumentText = document.text
 
         // Perform reformat on back-end, asynchronously
-        model.performReformat.start(componentLifetime, RdXamlStylerFormattingRequest(filePath, currentDocumentText)).result
-                .adviseOnce(componentLifetime) { it ->
+        model.performReformat.start(projectComponentLifetime, RdXamlStylerFormattingRequest(filePath, currentDocumentText)).result
+                .adviseOnce(projectComponentLifetime) {
                     val result = it.unwrap()
 
                     // Only update if backend actually made modifications


### PR DESCRIPTION
Addresses the following warnings from #296:

```
2020-08-17T22:39:00.9209657Z > Task :compileKotlin
2020-08-17T22:39:13.9240092Z w: D:\a\1\s\src\XamlStyler.Extension.Rider\rider\main\kotlin\xavalon\plugins\xamlstyler\rider\XamlStylerComponent.kt: (11, 41): 'ProtocolSubscribedProjectComponent' is deprecated. Use class from rd-platform
2020-08-17T22:39:13.9243190Z w: D:\a\1\s\src\XamlStyler.Extension.Rider\rider\main\kotlin\xavalon\plugins\xamlstyler\rider\XamlStylerComponent.kt: (19, 7): 'ProtocolSubscribedProjectComponent' is deprecated. Use class from rd-platform
2020-08-17T22:39:13.9244758Z w: D:\a\1\s\src\XamlStyler.Extension.Rider\rider\main\kotlin\xavalon\plugins\xamlstyler\rider\XamlStylerComponent.kt: (22, 53): 'getComponent(): TComponent' is deprecated. This API was moved to rd-platform
```

Warnings further down the log linked in #296 (beyond `2020-08-17T22:39:14.4259517Z > Task :prepareSandbox`) are harder to suppress. This part of the build essentially runs Rider (headless) to make a few sanity checks, which also contain standard warnings a regular Rider run would have. Can suppress them, but that would also suppress errors if they should occur :-/