### PR TITLE
New styler option - IgnoreEncodeForAttributes - to ignore xml encode inside of attribute values

### DIFF
--- a/src/XamlStyler.Console/Options.cs
+++ b/src/XamlStyler.Console/Options.cs
@@ -57,6 +57,9 @@ namespace Xavalon.XamlStyler.Console
         [Option("no-newline-elements", HelpText = "Override: no newline elements.")]
         public string NoNewLineElements { get; set; }
 
+        [Option("ignore-encode-for-attributes", HelpText = "Override: ignore encode for attributes.")]
+        public string IgnoreEncodeForAttributes { get; set; }
+
         [Option("attributes-order-groups-newline", HelpText = "Override: put attribute order rule groups on separate lines.")]
         public bool? PutAttributeOrderRuleGroupsOnSeparateLines { get; set; }
 

--- a/src/XamlStyler.Console/XamlStylerConsole.cs
+++ b/src/XamlStyler.Console/XamlStylerConsole.cs
@@ -68,6 +68,11 @@ namespace Xavalon.XamlStyler.Console
                 stylerOptions.NoNewLineElements = options.NoNewLineElements;
             }
 
+            if (options.IgnoreEncodeForAttributes != null)
+            {
+                stylerOptions.IgnoreEncodeForAttributes = options.IgnoreEncodeForAttributes;
+            }
+
             if (options.PutAttributeOrderRuleGroupsOnSeparateLines != null)
             {
                 stylerOptions.PutAttributeOrderRuleGroupsOnSeparateLines = options.PutAttributeOrderRuleGroupsOnSeparateLines.Value;

--- a/src/XamlStyler.UnitTests/FileHandlingIntegrationTests.cs
+++ b/src/XamlStyler.UnitTests/FileHandlingIntegrationTests.cs
@@ -449,6 +449,18 @@ namespace Xavalon.XamlStyler.UnitTests
             FileHandlingIntegrationTests.DoTest(stylerOptions);
         }
 
+        [Test]
+        public void TestAttributeIgnoreEncode()
+        {
+            var stylerOptions = new StylerOptions(
+                config: FileHandlingIntegrationTests.GetConfiguration(@"TestConfigurations\TestAttributeIgnoreEncode.json"))
+            {
+                IgnoreEncodeForAttributes = "Selector"
+            };
+
+            FileHandlingIntegrationTests.DoTest(stylerOptions);
+        }
+
         private static void DoTest(
             StylerOptions stylerOptions,
             [System.Runtime.CompilerServices.CallerMemberName] string callerMemberName = "")

--- a/src/XamlStyler.UnitTests/TestFiles/TestAttributeIgnoreEncode.expected
+++ b/src/XamlStyler.UnitTests/TestFiles/TestAttributeIgnoreEncode.expected
@@ -1,0 +1,5 @@
+﻿<Styles xmlns="https://github.com/avaloniaui">
+    <Style Selector="RadioButton > TextBlock">
+        <Setter Property="Foreground" Value="Green" />
+    </Style>
+</Styles>

--- a/src/XamlStyler.UnitTests/TestFiles/TestAttributeIgnoreEncode.testxaml
+++ b/src/XamlStyler.UnitTests/TestFiles/TestAttributeIgnoreEncode.testxaml
@@ -1,0 +1,5 @@
+﻿<Styles xmlns="https://github.com/avaloniaui">
+    <Style Selector="RadioButton > TextBlock">
+        <Setter Property="Foreground" Value="Green" />
+    </Style>
+</Styles>

--- a/src/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
+++ b/src/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
@@ -334,5 +334,11 @@
   <None Update="TestFiles\TestXmlSpaceHandling.testxaml">
     <CopyToOutputDirectory>Always</CopyToOutputDirectory>
   </None>
+  <None Update="TestFiles\TestAttributeIgnoreEncode.expected">
+    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+  </None>
+  <None Update="TestFiles\TestAttributeIgnoreEncode.testxaml">
+    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+  </None>
 </ItemGroup>
 </Project>

--- a/src/XamlStyler/DocumentProcessors/ElementDocumentProcessor.cs
+++ b/src/XamlStyler/DocumentProcessors/ElementDocumentProcessor.cs
@@ -24,6 +24,7 @@ namespace Xavalon.XamlStyler.DocumentProcessors
         private readonly XmlEscapingService xmlEscapingService;
         private readonly IList<string> noNewLineElementsList;
         private readonly IList<string> firstLineAttributes;
+        private readonly IList<string> ignoreEncodeForAttributes;
         private readonly string[] inlineCollections = { "TextBlock", "RichTextBlock", "Paragraph", "Run", "Span", "InlineUIContainer", "AnchoredBlock" };
         private readonly string[] inlineTypes = { "Paragraph", "Run", "Span", "InlineUIContainer", "AnchoredBlock", "Hyperlink", "Bold", "Italic", "Underline", "LineBreak" };
 
@@ -41,6 +42,7 @@ namespace Xavalon.XamlStyler.DocumentProcessors
             this.xmlEscapingService = xmlEscapingService;
             this.noNewLineElementsList = options.NoNewLineElements.ToList();
             this.firstLineAttributes = options.FirstLineAttributes.ToList();
+            this.ignoreEncodeForAttributes = options.IgnoreEncodeForAttributes.ToList();
         }
 
         public void Process(XmlReader xmlReader, StringBuilder output, ElementProcessContext elementProcessContext)
@@ -202,7 +204,8 @@ namespace Xavalon.XamlStyler.DocumentProcessors
             {
                 foreach (var attrInfo in list)
                 {
-                    output.Append(' ').Append(this.attributeInfoFormatter.ToSingleLineString(attrInfo));
+                    var ignoreEncode = IsIgnoreEncodeForAttributes(attrInfo.Name);
+                    output.Append(' ').Append(this.attributeInfoFormatter.ToSingleLineString(attrInfo, ignoreEncode));
                 }
 
                 elementProcessContext.Current.IsMultlineStartTag = false;
@@ -221,7 +224,8 @@ namespace Xavalon.XamlStyler.DocumentProcessors
                 string firstLine = String.Empty;
                 foreach (var attrInfo in firstLineList)
                 {
-                    firstLine = $"{firstLine} {this.attributeInfoFormatter.ToSingleLineString(attrInfo)}";
+                    var ignoreEncode = IsIgnoreEncodeForAttributes(attrInfo.Name);
+                    firstLine = $"{firstLine} {this.attributeInfoFormatter.ToSingleLineString(attrInfo, ignoreEncode)}";
                 }
 
                 if (firstLine.Length > 0)
@@ -252,7 +256,8 @@ namespace Xavalon.XamlStyler.DocumentProcessors
                     }
                     else
                     {
-                        string pendingAppend = this.attributeInfoFormatter.ToSingleLineString(attrInfo);
+                        var ignoreEncode = IsIgnoreEncodeForAttributes(attrInfo.Name);
+                        string pendingAppend = this.attributeInfoFormatter.ToSingleLineString(attrInfo, ignoreEncode);
                         var actualPendingAppend = this.xmlEscapingService.RestoreXmlnsAliasesBypass(pendingAppend);
                         xmlnsAliasesBypassLengthInCurrentLine += pendingAppend.Length - actualPendingAppend.Length;
 
@@ -351,6 +356,11 @@ namespace Xavalon.XamlStyler.DocumentProcessors
         private bool IsNoLineBreakElement(string elementName)
         {
             return this.noNewLineElementsList.Contains(elementName);
+        }
+
+        private bool IsIgnoreEncodeForAttributes(string attributeName)
+        {
+            return this.ignoreEncodeForAttributes.Contains(attributeName);
         }
     }
 }

--- a/src/XamlStyler/MarkupExtensions/Formatter/AttributeInfoFormatter.cs
+++ b/src/XamlStyler/MarkupExtensions/Formatter/AttributeInfoFormatter.cs
@@ -67,10 +67,10 @@ namespace Xavalon.XamlStyler.MarkupExtensions.Formatter
         /// </summary>
         /// <param name="attrInfo"></param>
         /// <returns></returns>
-        public string ToSingleLineString(AttributeInfo attrInfo)
+        public string ToSingleLineString(AttributeInfo attrInfo, bool ignoreEncode)
         {
-            var valuePart = attrInfo.IsMarkupExtension
-                ? this.formatter.FormatSingleLine(attrInfo.MarkupExtension)
+            var valuePart = attrInfo.IsMarkupExtension ? this.formatter.FormatSingleLine(attrInfo.MarkupExtension)
+                : ignoreEncode ? attrInfo.Value
                 : attrInfo.Value.ToXmlEncodedString();
 
             return $"{attrInfo.Name}=\"{valuePart}\"";

--- a/src/XamlStyler/Options/DefaultSettings.json
+++ b/src/XamlStyler/Options/DefaultSettings.json
@@ -4,6 +4,7 @@
   "MaxAttributeCharactersPerLine": 0,
   "MaxAttributesPerLine": 1,
   "NewlineExemptionElements": "RadialGradientBrush, GradientStop, LinearGradientBrush, ScaleTransform, SkewTransform, RotateTransform, TranslateTransform, Trigger, Condition, Setter",
+  "IgnoreEncodeForAttributes": "",
   "SeparateByGroups": false,
   "AttributeIndentation": 0,
   "AttributeIndentationStyle": 1,

--- a/src/XamlStyler/Options/IStylerOptions.cs
+++ b/src/XamlStyler/Options/IStylerOptions.cs
@@ -36,6 +36,8 @@ namespace Xavalon.XamlStyler.Options
 
         string NoNewLineElements { get; set; }
 
+        string IgnoreEncodeForAttributes { get; set; }
+
         bool PutAttributeOrderRuleGroupsOnSeparateLines { get; set; }
 
         int AttributeIndentation { get; set; }

--- a/src/XamlStyler/Options/StylerOptions.cs
+++ b/src/XamlStyler/Options/StylerOptions.cs
@@ -106,9 +106,9 @@ namespace Xavalon.XamlStyler.Options
         public string NoNewLineElements { get; set; }
 
         [Category("Attribute Formatting")]
-        [DisplayName("IgnoreEncodeForAttributes")]
+        [DisplayName("Ignore encode for attributes")]
         [JsonProperty("IgnoreEncodeForAttributes", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        [Description("IgnoreEncodeForAttributes.\r\n\r\nDefault Value: None")]
+        [Description("Defines whether properties shouldn't be encoded.\r\n\r\nDefault Value: None")]
         [DefaultValue("")]
         public string IgnoreEncodeForAttributes { get; set; }
 

--- a/src/XamlStyler/Options/StylerOptions.cs
+++ b/src/XamlStyler/Options/StylerOptions.cs
@@ -106,6 +106,13 @@ namespace Xavalon.XamlStyler.Options
         public string NoNewLineElements { get; set; }
 
         [Category("Attribute Formatting")]
+        [DisplayName("IgnoreEncodeForAttributes")]
+        [JsonProperty("IgnoreEncodeForAttributes", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [Description("IgnoreEncodeForAttributes.\r\n\r\nDefault Value: None")]
+        [DefaultValue("")]
+        public string IgnoreEncodeForAttributes { get; set; }
+
+        [Category("Attribute Formatting")]
         [DisplayName("Separate by groups")]
         [JsonProperty("SeparateByGroups", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         [Description("Defines whether attributes belonging to different rule groups should be put on separate lines, while, if possible, keeping attributes in the same group on the same line.\r\n\r\nDefault Value: false")]


### PR DESCRIPTION
### Description:

Fixes #302

Allow to configure specific xml-attributes to not be encoded with new styler option IgnoreEncodeForAttributes (name could be changed).
Documentation update is required.

### Checklist:
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] I have tested my changes by running the extension in VS2017
* [x] I have tested my changes by running the extension in VS2019
* [x] If changes to the [documentation](https://github.com/Xavalon/XamlStyler/wiki) are needed, I have noted this in the description above
