### PR TITLE
Trim property attribute value

### DIFF
--- a/src/XamlStyler/DocumentManipulation/FormatThicknessService.cs
+++ b/src/XamlStyler/DocumentManipulation/FormatThicknessService.cs
@@ -41,13 +41,20 @@ namespace Xavalon.XamlStyler.DocumentManipulation
             if (element.Name == SetterName)
             {
                 var propertyAttribute = element.Attributes("Property").FirstOrDefault();
-                if ((propertyAttribute != null) && !propertyAttribute.Value.Contains(":")
-                    && this.ThicknessAttributeNames.Any(_ => _.IsMatch(propertyAttribute.Value)))
+
+                if (propertyAttribute != null)
                 {
-                    var valueAttribute = element.Attributes("Value").FirstOrDefault();
-                    if (valueAttribute != null)
+                    // Trim the property attribute value to prevent exceptions with IsMatch
+                    propertyAttribute.Value = propertyAttribute.Value.Trim();
+
+                    if (!propertyAttribute.Value.Contains(":")
+                        && this.ThicknessAttributeNames.Any(_ => _.IsMatch(propertyAttribute.Value)))
                     {
-                        this.FormatAttribute(valueAttribute);
+                        var valueAttribute = element.Attributes("Value").FirstOrDefault();
+                        if (valueAttribute != null)
+                        {
+                            this.FormatAttribute(valueAttribute);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->

### Description:

Trim the property attribute value in FormatThicknessService to prevent an exception when processing IsMatch.

Fixes # [371](https://github.com/Xavalon/XamlStyler/issues/371)

<!-- Please include a summary of your changes. Provide enough information so that others can review your pull request. -->

### Checklist:
* [X] I have commented my code, particularly in hard-to-understand areas
* [X] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [X] New and existing unit tests pass locally with my changes
* [ ] I have tested my changes by running the extension in VS2017
* [ ] I have tested my changes by running the extension in VS2019
* [X] I have tested my changes by running the extension in VS2022
* [ ] If changes to the [documentation](https://github.com/Xavalon/XamlStyler/wiki) are needed, I have noted this in the description above
