### PR TITLE
Added ShowMessageBoxOnError option

### DIFF
--- a/src/XamlStyler.Extension.Windows.Shared/StylerPackage.Formatting.cs
+++ b/src/XamlStyler.Extension.Windows.Shared/StylerPackage.Formatting.cs
@@ -25,13 +25,19 @@ namespace Xavalon.XamlStyler.Extension.Windows
             }
             catch (Exception ex)
             {
-                this.ShowMessageBox(ex);
+                IStylerOptions options = this.optionsHelper.GetDocumentStylerOptions(document);
+                if (options.ShowMessageBoxOnError)
+                {
+                    this.ShowMessageBox(ex);
+                }
             }
         }
 
         private void FormatDocument(ProjectItem projectItem)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
+            Document document = projectItem.Document;
+
             try
             {
                 if (projectItem.IsFormatable())
@@ -50,8 +56,7 @@ namespace Xavalon.XamlStyler.Extension.Windows
                             // Skip if file cannot be opened.
                         }
                     }
-
-                    Document document = projectItem.Document;
+                    
                     if (document != null)
                     {
                         document.Activate();
@@ -68,7 +73,11 @@ namespace Xavalon.XamlStyler.Extension.Windows
             }
             catch (Exception ex)
             {
-                this.ShowMessageBox(ex);
+                IStylerOptions options = this.optionsHelper.GetDocumentStylerOptions(document);
+                if (options.ShowMessageBoxOnError)
+                {
+                    this.ShowMessageBox(ex);
+                }
             }
         }
 

--- a/src/XamlStyler.UnitTests/TestConfigurations/AllDifferent.json
+++ b/src/XamlStyler.UnitTests/TestConfigurations/AllDifferent.json
@@ -27,6 +27,7 @@
   "ThicknessAttributes": "Margin",
   "FormatOnSave": false,
   "SaveAndCloseOnFormat": false,
+  "ShowMessageBoxOnError": false,
   "CommentPadding": 3,
   "IgnoreDesignTimeReferencePrefix": true
 }

--- a/src/XamlStyler.UnitTests/TestConfigurations/BadSetting.json
+++ b/src/XamlStyler.UnitTests/TestConfigurations/BadSetting.json
@@ -38,6 +38,7 @@
   "ThicknessAttributes": "Margin, Padding, BorderThickness, ThumbnailClipMargin",
   "FormatOnSave": true,
   "SaveAndCloseOnFormat": true,
+  "ShowMessageBoxOnError": true,
   "CommentPadding": 2,
   "TestBool": true,
   "TestInt": 1,

--- a/src/XamlStyler.UnitTests/TestConfigurations/Default.json
+++ b/src/XamlStyler.UnitTests/TestConfigurations/Default.json
@@ -38,6 +38,7 @@
   "ThicknessAttributes": "Margin, Padding, BorderThickness, ThumbnailClipMargin",
   "FormatOnSave": true,
   "SaveAndCloseOnFormat": true,
+  "ShowMessageBoxOnError": true,
   "CommentPadding": 2,
   "SearchToDriveRoot": true,
   "IgnoreDesignTimeReferencePrefix": false

--- a/src/XamlStyler/Options/DefaultSettings.json
+++ b/src/XamlStyler/Options/DefaultSettings.json
@@ -38,6 +38,7 @@
   "ThicknessAttributes": "Margin, Padding, BorderThickness, ThumbnailClipMargin",
   "FormatOnSave": true,
   "SaveAndCloseOnFormat": true,
+  "ShowMessageBoxOnError":  true,
   "CommentPadding": 2,
   "SearchToDriveRoot": true
 }

--- a/src/XamlStyler/Options/IStylerOptions.cs
+++ b/src/XamlStyler/Options/IStylerOptions.cs
@@ -105,6 +105,8 @@ namespace Xavalon.XamlStyler.Options
 
         bool SaveAndCloseOnFormat { get; set; }
 
+        bool ShowMessageBoxOnError { get; set; }
+
         int CommentSpaces { get; set; }
 
         #endregion Misc

--- a/src/XamlStyler/Options/StylerOptions.cs
+++ b/src/XamlStyler/Options/StylerOptions.cs
@@ -282,6 +282,13 @@ namespace Xavalon.XamlStyler.Options
         public bool SaveAndCloseOnFormat { get; set; }
 
         [Category("Misc")]
+        [DisplayName("Show message box with details on format error?")]
+        [JsonProperty("ShowMessageBoxOnError", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [Description("When set to true, XAML Styler will popup a message box with the error details when formatting fails.\r\n\r\nDefault Value: true")]
+        [DefaultValue(true)]
+        public bool ShowMessageBoxOnError { get; set; }
+
+        [Category("Misc")]
         [DisplayName("Comment padding")]
         [JsonProperty("CommentPadding", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         [Description("Determines the number of spaces a XAML comment should be padded with.\r\n\r\nDefault Value: 2")]


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->

### Description:

Fixes #387 Add option to hide "Error in StylerPackage" popup message

Created a new setting called `ShowMessageBoxOnError` in `StylerOptions` and `IStylerOptions`. This setting then is used in `StylerPackage.Formatting` whenever the `ShowMessageBox` function is called.

If `ShowMessageBoxOnError = false`, the message box will not be shown.

### Checklist:
* [x] Code required no comments due to simplicity
* [x] My changes generate no new warnings
* [x] New and existing unit tests pass locally with my changes
* [x] I have tested my changes by running the extension in VS2019
* [x] I have tested my changes by running the extension in VS2022
