### PR TITLE
Add net6.0 target framework in console project

### DIFF
--- a/build/pipelines/templates/build-console-public.yaml
+++ b/build/pipelines/templates/build-console-public.yaml
@@ -15,10 +15,10 @@ jobs:
       pwsh: true
 
   - task: UseDotNet@2
-    displayName: 'Use .NET Core 3.1 SDK'
+    displayName: 'Use .NET Core 6 SDK'
     inputs:
       packageType: sdk
-      version: 3.1.x
+      version: 6.0.x
       installationPath: $(Agent.ToolsDirectory)/dotnet
 
   # The first task is the dotnet command build, pointing to our csproj file

--- a/src/XamlStyler.Console/XamlStyler.Console.csproj
+++ b/src/XamlStyler.Console/XamlStyler.Console.csproj
@@ -13,7 +13,7 @@
     <RepositoryUrl>https://github.com/Xavalon/XamlStyler</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <RootNamespace>Xavalon.XamlStyler.Console</RootNamespace>
     <AssemblyName>xstyler</AssemblyName>
     <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->

### Description:

This PR add a net6.0 target to the console project. Users with only .NET 6 runtime installed can run the console tool after this change.

Fixes #378

<!-- Please include a summary of your changes. Provide enough information so that others can review your pull request. -->

### Checklist:
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] I have tested my changes by running the extension in VS2017
* [ ] I have tested my changes by running the extension in VS2019
* [ ] I have tested my changes by running the extension in VS2022
* [ ] If changes to the [documentation](https://github.com/Xavalon/XamlStyler/wiki) are needed, I have noted this in the description above
