### PR TITLE
Normalize paths before attempting to find external config file

### DIFF
--- a/src/XamlStyler.Extension.Rider/dotnet/Xavalon.XamlStyler.Extension.Rider/StylerOptionsFactory.cs
+++ b/src/XamlStyler.Extension.Rider/dotnet/Xavalon.XamlStyler.Extension.Rider/StylerOptionsFactory.cs
@@ -27,12 +27,16 @@ namespace Xavalon.XamlStyler.Extension.Rider
                 sourceFilePath: psiSourceFileWithLocation?.Location.FullPath);
         }
         
-         public static IStylerOptions FromSettings(
+        public static IStylerOptions FromSettings(
             IContextBoundSettingsStoreLive settings,
             [CanBeNull] ISolution solution,
             [CanBeNull] string projectPath,
             [CanBeNull] string sourceFilePath)
         {
+             // Normalize paths, because Rider may pass them in with differing separator chars
+             projectPath = NormalizePath(projectPath);
+             sourceFilePath = NormalizePath(sourceFilePath);
+
             // 1. Load global settings
             IStylerOptions fallbackOptions = new StylerOptions();
             IStylerOptions stylerOptions = new StylerOptions();
@@ -141,6 +145,17 @@ namespace Xavalon.XamlStyler.Extension.Rider
             }
 
             return null;
+        }
+
+        private static string NormalizePath(string path)
+        {
+            if (path.IsNullOrEmpty())
+            {
+                return null;
+            }
+
+            return Path.GetFullPath(new Uri(path).LocalPath)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         }
     }
 }


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->

### Description:

Fixes #308 

The problem was caused by the paths being passed in from Rider sometimes having differing separator chars, e.g.
`C:\example\path\app.sln` vs. `C:/example/path/app/views/mainwindow.xaml`

This would cause XamlStyler to only check the directory where the file being formatted is located for an external config file, since no part of the two paths are matching.

### Checklist:
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] I have tested my changes by running the extension in VS2017
* [ ] I have tested my changes by running the extension in VS2019
* [ ] I have tested my changes by running the extension in VS2022
* [x] I have tested my changes by running the extension in Rider
* [x] If changes to the [documentation](https://github.com/Xavalon/XamlStyler/wiki) are needed, I have noted this in the description above
