### PR TITLE
Fix Rider 2022.2 support

### DIFF
--- a/src/XamlStyler.Extension.Rider/build.gradle
+++ b/src/XamlStyler.Extension.Rider/build.gradle
@@ -6,10 +6,10 @@ plugins {
 
     // RIDER: May need updating with new Rider releases
     id 'org.jetbrains.kotlin.jvm' version '1.7.0-RC'
-    id 'com.jetbrains.rdgen' version '2022.1.1'
+    id 'com.jetbrains.rdgen' version '2022.2.1'
 
     // RIDER: Will probably need updating with new Rider releases, use latest version number from https://github.com/JetBrains/gradle-intellij-plugin/releases
-    id 'org.jetbrains.intellij' version '1.6.0'
+    id 'org.jetbrains.intellij' version '1.8.0'
 }
 
 ext {

--- a/src/XamlStyler.Extension.Rider/dotnet/Plugin.props
+++ b/src/XamlStyler.Extension.Rider/dotnet/Plugin.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- RIDER: To be updated with new Rider release -->
-    <SdkVersion>2022.1.1</SdkVersion>
+    <SdkVersion>2022.2.1</SdkVersion>
     
     <Title>XAML Styler</Title>
     <Description>XAML Styler is an extension that formats XAML source code based on a set of styling rules. This tool can help you/your team maintain a better XAML coding style as well as a much better XAML readability.</Description>

--- a/src/XamlStyler.Extension.Rider/gradle.properties
+++ b/src/XamlStyler.Extension.Rider/gradle.properties
@@ -18,4 +18,4 @@ BuildConfiguration=Release
 #    2021.2 (stable versions)
 #
 # RIDER: To be updated with new Rider release
-ProductVersion=2022.1
+ProductVersion=2022.2


### PR DESCRIPTION
### Description: 

Added Rider 2022.2 as new target

Fixes #402

Updated sdk target versions.
Updated build props.

### Checklist:
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] I have tested my changes by running the extension in VS2017
* [ ] I have tested my changes by running the extension in VS2019
* [ ] I have tested my changes by running the extension in VS2022
* [x] I have tested my changes by running the extension in Rider 2022.2
* [ ] If changes to the [documentation](https://github.com/Xavalon/XamlStyler/wiki) are needed, I have noted this in the description above
