### PR TITLE
Support Rider 2023.2

### DIFF
--- a/build/pipelines/templates/build-extension-rider-public.yaml
+++ b/build/pipelines/templates/build-extension-rider-public.yaml
@@ -29,7 +29,7 @@ jobs:
       gradleOptions: '-Xmx3072m'
       options: '-PPluginVersion=$(pluginVersion)'
       javaHomeOption: 'JDKVersion'
-      jdkVersionOption: '1.11'
+      jdkVersionOption: '1.17'
       jdkArchitectureOption: 'x64'
       publishJUnitResults: true
       testResultsFiles: '**/TEST-*.xml'

--- a/src/XamlStyler.Extension.Rider/build.gradle
+++ b/src/XamlStyler.Extension.Rider/build.gradle
@@ -9,7 +9,7 @@ plugins {
     id 'com.jetbrains.rdgen' version '2023.2.0'
 
     // RIDER: Will probably need updating with new Rider releases, use latest version number from https://github.com/JetBrains/gradle-intellij-plugin/releases
-    id 'org.jetbrains.intellij' version '1.13.3'
+    id 'org.jetbrains.intellij' version '1.15.0'
 }
 
 ext {

--- a/src/XamlStyler.Extension.Rider/dotnet/Plugin.props
+++ b/src/XamlStyler.Extension.Rider/dotnet/Plugin.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <!-- RIDER: To be updated with new Rider release -->
-    <SdkVersion>2023.1.0</SdkVersion>
     
+    <SdkVersion>2023.2.0</SdkVersion>
     <Title>XAML Styler</Title>
     <Description>XAML Styler is an extension that formats XAML source code based on a set of styling rules. This tool can help you/your team maintain a better XAML coding style as well as a much better XAML readability.</Description>
   

--- a/src/XamlStyler.Extension.Rider/gradle.properties
+++ b/src/XamlStyler.Extension.Rider/gradle.properties
@@ -18,4 +18,4 @@ BuildConfiguration=Release
 #    2021.2 (stable versions)
 #
 # RIDER: To be updated with new Rider release
-ProductVersion=2023.1
+ProductVersion=2023.2


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->

### Description:

Fixes #433 

Adds support for Rider 2023.2, which requires JDK 17 to build.

### Checklist:
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] I have tested my changes by running the extension in VS2017
* [ ] I have tested my changes by running the extension in VS2019
* [ ] I have tested my changes by running the extension in VS2022
* [x] If changes to the [documentation](https://github.com/Xavalon/XamlStyler/wiki) are needed, I have noted this in the description above
