### PR TITLE
Updating packages and fixing warnings

### DIFF
--- a/build/pipelines/templates/build-extension-public.yaml
+++ b/build/pipelines/templates/build-extension-public.yaml
@@ -33,7 +33,7 @@ jobs:
     displayName: 'Build'
     inputs:
       solution: src/XamlStyler.sln
-      vsVersion: 16.0
+      vsVersion: latest
       platform: 'Any CPU'
       configuration: $(buildConfiguration)
       clean: true

--- a/src/XamlStyler.Console/XamlStyler.Console.csproj
+++ b/src/XamlStyler.Console/XamlStyler.Console.csproj
@@ -29,17 +29,17 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser">
-      <Version>2.8.0</Version>
+      <Version>2.9.1</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.3</Version>
+      <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="NuGet.CommandLine">
-      <Version>6.0.2</Version>
+      <Version>6.6.1</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/XamlStyler.Console/XamlStyler.Console.csproj
+++ b/src/XamlStyler.Console/XamlStyler.Console.csproj
@@ -20,6 +20,7 @@
     <ToolCommandName>xstyler</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OutputPath>..\bin\Debug\Console\</OutputPath>
@@ -30,10 +31,6 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser">
       <Version>2.9.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>

--- a/src/XamlStyler.Extension.Windows.VS2019/XamlStyler.Extension.Windows.VS2019.csproj
+++ b/src/XamlStyler.Extension.Windows.VS2019/XamlStyler.Extension.Windows.VS2019.csproj
@@ -98,7 +98,7 @@
       <Version>15.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.2.2200</Version>
+      <Version>17.5.4074</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/XamlStyler.Extension.Windows.VS2019/XamlStyler.Extension.Windows.VS2019.csproj
+++ b/src/XamlStyler.Extension.Windows.VS2019/XamlStyler.Extension.Windows.VS2019.csproj
@@ -87,10 +87,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CompareNETObjects">
-      <Version>4.77.0</Version>
+      <Version>4.79.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
-      <Version>6.0.0</Version>
+      <Version>7.0.3</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -98,7 +98,7 @@
       <Version>15.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.2.2186</Version>
+      <Version>17.2.2200</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/XamlStyler.Extension.Windows.VS2022/XamlStyler.Extension.Windows.VS2022.csproj
+++ b/src/XamlStyler.Extension.Windows.VS2022/XamlStyler.Extension.Windows.VS2022.csproj
@@ -87,10 +87,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CompareNETObjects">
-      <Version>4.77.0</Version>
+      <Version>4.79.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
-      <Version>6.0.0</Version>
+      <Version>7.0.3</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -98,7 +98,7 @@
       <Version>17.0.31902.203</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.2.2186</Version>
+      <Version>17.2.2200</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/XamlStyler.Extension.Windows.VS2022/XamlStyler.Extension.Windows.VS2022.csproj
+++ b/src/XamlStyler.Extension.Windows.VS2022/XamlStyler.Extension.Windows.VS2022.csproj
@@ -95,10 +95,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>17.0.31902.203</Version>
+      <Version>17.5.33428.388</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.2.2200</Version>
+      <Version>17.5.4074</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/XamlStyler.UnitTests/FileHandlingIntegrationTests.cs
+++ b/src/XamlStyler.UnitTests/FileHandlingIntegrationTests.cs
@@ -510,7 +510,7 @@ namespace Xavalon.XamlStyler.UnitTests
 
         private static void DoTest(StylerService stylerService, StylerOptions stylerOptions, string testFileBaseName, string expectedSuffix)
         {
-            var activeDir = Path.GetDirectoryName(new Uri(typeof(FileHandlingIntegrationTests).Assembly.CodeBase).LocalPath);
+            var activeDir = Path.GetDirectoryName(new Uri(typeof(FileHandlingIntegrationTests).Assembly.Location).LocalPath);
             var testFile = Path.Combine(activeDir, testFileBaseName);
 
             var testFileResultBaseName = (expectedSuffix != null)

--- a/src/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
+++ b/src/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
@@ -6,6 +6,8 @@
     <Copyright>Copyright © Xavalon 2020</Copyright>
     <Company>Xavalon</Company>
     <Configurations>Debug;Release;Debug VS2019;Release VS2019</Configurations>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -28,12 +30,8 @@
     </PackageReference>
     <PackageReference Include="Irony" Version="1.2.0">
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3">
     </PackageReference>
     <PackageReference Include="NUnit" Version="3.13.3">
     </PackageReference>

--- a/src/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
+++ b/src/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
@@ -24,11 +24,11 @@
     <OutputPath>..\bin\Release\UnitTest</OutputPath>
   </PropertyGroup>
 <ItemGroup>
-    <PackageReference Include="CompareNETObjects" Version="4.77.0">
+    <PackageReference Include="CompareNETObjects" Version="4.79.0">
     </PackageReference>
-    <PackageReference Include="Irony" Version="1.1.0">
+    <PackageReference Include="Irony" Version="1.2.0">
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -37,9 +37,9 @@
     </PackageReference>
     <PackageReference Include="NUnit" Version="3.13.3">
     </PackageReference>
-    <PackageReference Include="NUnit.ConsoleRunner" Version="3.15.0">
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.16.3">
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
     </PackageReference>
   </ItemGroup>
 <ItemGroup>

--- a/src/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
+++ b/src/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RootNamespace>Xavalon.XamlStyler.UnitTests</RootNamespace>
     <Copyright>Copyright © Xavalon 2020</Copyright>
     <Company>Xavalon</Company>

--- a/src/XamlStyler/XamlStyler.csproj
+++ b/src/XamlStyler/XamlStyler.csproj
@@ -24,9 +24,9 @@
     <EmbeddedResource Include="Options\DefaultSettings.json" />
   </ItemGroup>
 <ItemGroup>
-    <PackageReference Include="Irony" Version="1.1.0">
+    <PackageReference Include="Irony" Version="1.2.0">
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/XamlStyler/XamlStyler.csproj
+++ b/src/XamlStyler/XamlStyler.csproj
@@ -6,6 +6,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
     <Copyright>Copyright © Xavalon 2020</Copyright>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -25,10 +26,6 @@
   </ItemGroup>
 <ItemGroup>
     <PackageReference Include="Irony" Version="1.2.0">
-    </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1">
     </PackageReference>


### PR DESCRIPTION
### Description: Updating packages and fixing warnings

- Updated all packages to latest versions that do not break compatibility.
- Updated UnitTest project to net7.0 to support pipeline updates
- Cleaned up build and pipeline warnings

This change supersedes certain package updates in #419, but shoutout to @virzak for some project optimizations made in this PR. 

Please note that we are unable to update certain projects to newer versions of Newtonsoft.Json due to Visual Studio compatability. More information here: [Using Newtonsoft.Json in a Visual Studio extension](https://devblogs.microsoft.com/visualstudio/using-newtonsoft-json-in-a-visual-studio-extension/).

### Checklist:
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] I have tested my changes by running the extension in VS2017
* [x] I have tested my changes by running the extension in VS2019
* [x] I have tested my changes by running the extension in VS2022
* [ ] If changes to the [documentation](https://github.com/Xavalon/XamlStyler/wiki) are needed, I have noted this in the description above