### PR TITLE
Console: Add option to write formatted output to stdout instead of modifying the file

### DIFF
--- a/src/XamlStyler.Console/Logger.cs
+++ b/src/XamlStyler.Console/Logger.cs
@@ -1,0 +1,24 @@
+// © Xavalon. All rights reserved.
+
+namespace Xavalon.XamlStyler.Console
+{
+    public sealed class Logger
+    {
+        private readonly System.IO.TextWriter writer;
+        private readonly LogLevel level;
+
+        public Logger(System.IO.TextWriter writer, LogLevel level)
+        {
+            this.writer = writer;
+            this.level = level;
+        }
+
+        public void Log(string line, LogLevel level = LogLevel.Default)
+        {
+            if (level <= this.level)
+            {
+                this.writer.WriteLine(line);
+            }
+        }
+    }
+}

--- a/src/XamlStyler.Console/Options.cs
+++ b/src/XamlStyler.Console/Options.cs
@@ -29,7 +29,7 @@ namespace Xavalon.XamlStyler.Console
         public bool IsPassive { get; set; }
 
         [Option("write-to-stdout", Default = false,
-            HelpText = "Instead of modifying the file, write to stdout. In this mode, logs are printed to stderr. Must specify exactly one file.")]
+            HelpText = "Instead of modifying the file, write to stdout. In this mode, logs are printed to stderr. Must specify exactly one file. Cannot be compbined with --passive.")]
         public bool WriteToStdout { get; set; }
 
         [Option('l', "loglevel", Default = LogLevel.Default,

--- a/src/XamlStyler.Console/Options.cs
+++ b/src/XamlStyler.Console/Options.cs
@@ -28,6 +28,10 @@ namespace Xavalon.XamlStyler.Console
         [Option('p', "passive", Default = false, HelpText = "Check files follow proper formatting without making any modifications. Returns error status if files fail the check.")]
         public bool IsPassive { get; set; }
 
+        [Option("write-to-stdout", Default = false,
+            HelpText = "Instead of modifying the file, write to stdout. In this mode, logs are printed to stderr.")]
+        public bool WriteToStdout { get; set; }
+
         [Option('l', "loglevel", Default = LogLevel.Default,
             HelpText = "Levels in order of increasing detail: None, Minimal, Default, Verbose, Debug")]
         public LogLevel LogLevel { get; set; }

--- a/src/XamlStyler.Console/Options.cs
+++ b/src/XamlStyler.Console/Options.cs
@@ -29,7 +29,7 @@ namespace Xavalon.XamlStyler.Console
         public bool IsPassive { get; set; }
 
         [Option("write-to-stdout", Default = false,
-            HelpText = "Instead of modifying the file, write to stdout. In this mode, logs are printed to stderr.")]
+            HelpText = "Instead of modifying the file, write to stdout. In this mode, logs are printed to stderr. Must specify exactly one file.")]
         public bool WriteToStdout { get; set; }
 
         [Option('l', "loglevel", Default = LogLevel.Default,

--- a/src/XamlStyler.Console/Program.cs
+++ b/src/XamlStyler.Console/Program.cs
@@ -16,7 +16,7 @@ namespace Xavalon.XamlStyler.Console
 
             result.WithNotParsed(_ =>
             {
-                System.Console.WriteLine(writer.ToString());
+                System.Console.Error.WriteLine(writer.ToString());
                 Environment.Exit(1);
             })
             .WithParsed(options =>
@@ -50,24 +50,24 @@ namespace Xavalon.XamlStyler.Console
             bool isDirectoryOptionSpecified = !String.IsNullOrEmpty(options.Directory);
             if (isFileOptionSpecified && isDirectoryOptionSpecified)
             {
-                System.Console.WriteLine($"\nError: Cannot specify both file(s) and directory\n");
+                System.Console.Error.WriteLine($"\nError: Cannot specify both file(s) and directory\n");
                 result = false;
             }
             else if (!isFileOptionSpecified && !isDirectoryOptionSpecified)
             {
-                System.Console.WriteLine($"\nError: Must specify file(s) or directory\n");
+                System.Console.Error.WriteLine($"\nError: Must specify file(s) or directory\n");
                 result = false;
             }
 
             if (options.WriteToStdout && (isDirectoryOptionSpecified || numFilesSpecified != 1))
             {
-                System.Console.WriteLine($"\nError: When using --write-to-stdout you must specify exactly one file\n");
+                System.Console.Error.WriteLine($"\nError: When using --write-to-stdout you must specify exactly one file\n");
                 result = false;
             }
 
             if (options.WriteToStdout && options.IsPassive)
             {
-                System.Console.WriteLine($"\nError: Cannot specify both --passive and --write-to-stdout\n");
+                System.Console.Error.WriteLine($"\nError: Cannot specify both --passive and --write-to-stdout\n");
                 result = false;
             }
 

--- a/src/XamlStyler.Console/Program.cs
+++ b/src/XamlStyler.Console/Program.cs
@@ -21,27 +21,26 @@ namespace Xavalon.XamlStyler.Console
             })
             .WithParsed(options =>
             {
+                Logger logger = new Logger(options.WriteToStdout ? System.Console.Error : System.Console.Out, options.LogLevel);
+
                 ProcessType processType;
-                if (!CheckOptions(options, out processType))
+                if (!CheckOptions(options, logger, out processType))
                 {
                     Environment.Exit(1);
                 }
 
-                var xamlStylerConsole = new XamlStylerConsole(options);
+                var xamlStylerConsole = new XamlStylerConsole(options, logger);
                 xamlStylerConsole.Process(processType);
             });
 
             return 0;
         }
 
-        private static bool CheckOptions(CommandLineOptions options, out ProcessType processType)
+        private static bool CheckOptions(CommandLineOptions options, Logger logger, out ProcessType processType)
         {
-            if (options.LogLevel >= LogLevel.Debug)
-            {
-                System.Console.WriteLine($"File Parameter: '{options.File}'");
-                System.Console.WriteLine($"File Count: {options.File?.Count ?? -1}");
-                System.Console.WriteLine($"File Directory: '{options.Directory}'");
-            }
+            logger.Log($"File Parameter: '{options.File}'", LogLevel.Debug);
+            logger.Log($"File Count: {options.File?.Count ?? -1}", LogLevel.Debug);
+            logger.Log($"File Directory: '{options.Directory}'", LogLevel.Debug);
 
             bool result = true;
 

--- a/src/XamlStyler.Console/Program.cs
+++ b/src/XamlStyler.Console/Program.cs
@@ -28,10 +28,15 @@ namespace Xavalon.XamlStyler.Console
                     System.Console.WriteLine($"File Directory: '{options.Directory}'");
                 }
 
-                bool isFileOptionSpecified = (options.File?.Count ?? 0) != 0;
+                int numFilesSpecified = options.File?.Count ?? 0;
+                bool isFileOptionSpecified = numFilesSpecified != 0;
                 bool isDirectoryOptionSpecified = !String.IsNullOrEmpty(options.Directory);
 
-                if (isFileOptionSpecified ^ isDirectoryOptionSpecified)
+                if (options.WriteToStdout && (isDirectoryOptionSpecified || numFilesSpecified != 1))
+                {
+                    System.Console.WriteLine($"\nError: When using --write-to-stdout you must specify exactly one file\n");
+                }
+                else if (isFileOptionSpecified ^ isDirectoryOptionSpecified)
                 {
                     var xamlStylerConsole = new XamlStylerConsole(options);
                     xamlStylerConsole.Process(isFileOptionSpecified ? ProcessType.File : ProcessType.Directory);

--- a/src/XamlStyler.Console/Program.cs
+++ b/src/XamlStyler.Console/Program.cs
@@ -36,6 +36,10 @@ namespace Xavalon.XamlStyler.Console
                 {
                     System.Console.WriteLine($"\nError: When using --write-to-stdout you must specify exactly one file\n");
                 }
+                else if (options.WriteToStdout && options.IsPassive)
+                {
+                    System.Console.WriteLine($"\nError: Cannot specify both --passive and --write-to-stdout\n");
+                }
                 else if (isFileOptionSpecified ^ isDirectoryOptionSpecified)
                 {
                     var xamlStylerConsole = new XamlStylerConsole(options);

--- a/src/XamlStyler.Console/XamlStylerConsole.cs
+++ b/src/XamlStyler.Console/XamlStylerConsole.cs
@@ -263,6 +263,20 @@ namespace Xavalon.XamlStyler.Console
                     return false;
                 }
             }
+            else if (this.options.WriteToStdout)
+            {
+                var prevEncoding = System.Console.OutputEncoding;
+                try
+                {
+                    System.Console.OutputEncoding = encoding;
+                    System.Console.Write(encoding.GetString(encoding.GetPreamble()));
+                    System.Console.Write(formattedOutput);
+                }
+                finally
+                {
+                    System.Console.OutputEncoding = prevEncoding;
+                }
+            }
             else
             {
                 this.Log($"\nFormatted Output:\n\n{formattedOutput}\n", LogLevel.Insanity);
@@ -336,7 +350,14 @@ namespace Xavalon.XamlStyler.Console
         {
             if (logLevel <= this.options.LogLevel)
             {
-                System.Console.WriteLine(value);
+                if (this.options.WriteToStdout)
+                {
+                    System.Console.Error.WriteLine(value);
+                }
+                else
+                {
+                    System.Console.WriteLine(value);
+                }
             }
         }
     }

--- a/src/XamlStyler.Console/XamlStylerConsole.cs
+++ b/src/XamlStyler.Console/XamlStylerConsole.cs
@@ -13,11 +13,13 @@ namespace Xavalon.XamlStyler.Console
     public sealed class XamlStylerConsole
     {
         private readonly CommandLineOptions options;
+        private readonly Logger logger;
         private readonly StylerService stylerService;
 
-        public XamlStylerConsole(CommandLineOptions options)
+        public XamlStylerConsole(CommandLineOptions options, Logger logger)
         {
             this.options = options;
+            this.logger = logger;
 
             IStylerOptions stylerOptions = new StylerOptions();
 
@@ -346,19 +348,9 @@ namespace Xavalon.XamlStyler.Console
             return null;
         }
 
-        private void Log(string value, LogLevel logLevel = LogLevel.Default)
+        private void Log(string line, LogLevel logLevel = LogLevel.Default)
         {
-            if (logLevel <= this.options.LogLevel)
-            {
-                if (this.options.WriteToStdout)
-                {
-                    System.Console.Error.WriteLine(value);
-                }
-                else
-                {
-                    System.Console.WriteLine(value);
-                }
-            }
+            this.logger.Log(line, logLevel);
         }
     }
 }


### PR DESCRIPTION
### Description:

Fixes #440 

* Add option to write the formatted output to stdout instead of modifying the original file.
* When the option is enabled, logging is directed to stderr instead of stdout.
* Extracted the options error checking into a separate function.
* Improved the logging code a bit:
    * Extracted to a separate class, so that it can be used in Program as well without code duplication.
    * Errors in Program are always written to stderr.

Concerning the below checklist:
* All unit tests fail on my current platform (macOS). I've made a separate pull request to fix that (#439).
* I could not see any tests (unit or otherwise) for the console tool. Let me know if some should be added... somehow.
* Since I did not make any changes to the VS extensions and I don't have Windows, I didn't test the extensions.
* The [Script Integration](https://github.com/Xavalon/XamlStyler/wiki/Script-Integration) documentation page should be updated to include the new command line option.
    * Perhaps the [Git Hook](https://github.com/Xavalon/XamlStyler/wiki/Git-Hook) could also be updated to demonstrate how to use xstyler with partially staged changes. You can use this snippet if you like: https://gist.github.com/lysannschlegel/65cb7633458ab29ca6ad2fd3a3c06dcb

### Checklist:
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] I have tested my changes by running the extension in VS2017
* [ ] I have tested my changes by running the extension in VS2019
* [ ] I have tested my changes by running the extension in VS2022
* [x] If changes to the [documentation](https://github.com/Xavalon/XamlStyler/wiki) are needed, I have noted this in the description above
