### PR TITLE
Better handle internal VS exceptions relating to .csproj files

### DIFF
--- a/src/XamlStyler.Extension.Windows.Shared/Extensions/DocumentExtensions.cs
+++ b/src/XamlStyler.Extension.Windows.Shared/Extensions/DocumentExtensions.cs
@@ -30,13 +30,29 @@ namespace Xavalon.XamlStyler.Extension.Windows.Extensions
                    && document.FullName.EndsWith(Constants.AxamlFileExtension, StringComparison.OrdinalIgnoreCase);
         }
 
+        public static bool IsReadOnly(this Document document)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            try
+            {
+                return document.ReadOnly;
+            }
+            catch
+            {
+                // EnvDTE.Document.get_ReadOnly() *may* throw an Exception for some document types.
+            }
+
+            return false;
+        }
+
         public static XamlLanguageOptions GetXamlLanguageOptions(this Document document)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
             var options = new XamlLanguageOptions();
 
-            if (document == null || document.ReadOnly)
+            if (document == null || document.IsReadOnly())
             {
                 return options;
             }

--- a/src/XamlStyler.Extension.Windows.Shared/StylerPackage.cs
+++ b/src/XamlStyler.Extension.Windows.Shared/StylerPackage.cs
@@ -75,7 +75,7 @@ namespace Xavalon.XamlStyler.Extension.Windows
 
             // Format XAML File Command
             this.menuCommandService.AddCommand(new MenuCommand(
-                (s,e) => this.FormatFileEventHandler(),
+                (s, e) => this.FormatFileEventHandler(),
                 new CommandID(Guids.GuidXamlStylerMenuSet, (int)Constants.CommandIDFormatXamlFile)));
 
             // Format All XAML Command
@@ -101,7 +101,10 @@ namespace Xavalon.XamlStyler.Extension.Windows
         {
             ThreadHelper.ThrowIfNotOnUIThread();
             this.uiShell.SetWaitCursor();
-            this.FormatDocument(this.IDE2.ActiveDocument);
+            if (TryGetActiveDocument(out Document document))
+            {
+                this.FormatDocument(document);
+            }
         }
 
         private void FormatSolutionEventHandler()
@@ -135,11 +138,13 @@ namespace Xavalon.XamlStyler.Extension.Windows
                 return;
             }
 
-            Document document = this.IDE2.ActiveDocument;
-            IStylerOptions options = this.optionsHelper.GetDocumentStylerOptions(document);
-            if (options.FormatOnSave)
+            if (TryGetActiveDocument(out Document document))
             {
-                this.FormatDocument(document, options);
+                IStylerOptions options = this.optionsHelper.GetDocumentStylerOptions(document);
+                if (options.FormatOnSave)
+                {
+                    this.FormatDocument(document, options);
+                }
             }
         }
 
@@ -178,6 +183,23 @@ namespace Xavalon.XamlStyler.Extension.Windows
             {
                 finish();
             }
+        }
+
+        private bool TryGetActiveDocument(out Document document)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            try
+            {
+                document = this.IDE2.ActiveDocument;
+                return document != null;
+            }
+            catch
+            {
+                // EnvDTE80.DTE2.get_ActiveDocument() *may* throw an ArgumentNullException for some documents.
+            }
+
+            document = null;
+            return false;
         }
 
         private void ShowMessageBox(Exception ex)


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->

### Description: Stop internal VS exceptions causing the extension to break or report errors.

It seems that as of ~17.8, there are possible exceptions getting the ActiveDocument when it is an open `.csproj` file or querying whether it is read-only.
This PR adds exception trapping & suppressing for these possible (& now likely) scenarios.

Over many years of working with different file and project types within Visual Studio extensions, I've learned to be very wary of trusting that calls to properties of documents will always be available or returned without throwing an error. I'm surprised this project has gone so long without encountering such an issue before. (Although maybe #278 is an indication that it hasn't.)

These changes have been made in the shared Windows code, but I've only tested in VS2022.
I can't foresee any issues with them affecting the other VS (2019) build, though.

This change is Visual Studio-specific and will not affect the Rider build.


Fixes #448 (issue)

<!-- Please include a summary of your changes. Provide enough information so that others can review your pull request. -->

### Checklist:
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] I have tested my changes by running the extension in VS2017
* [ ] I have tested my changes by running the extension in VS2019
* [x] I have tested my changes by running the extension in VS2022
* [ ] If changes to the [documentation](https://github.com/Xavalon/XamlStyler/wiki) are needed, I have noted this in the description above

I have tested with VS 17.8.2 and 17.9.0 Preview 1.1 - The two specific issues I have added exception handling for were happening separately on each of the versions.

