### PR TITLE
Remove inclusion of context menu in all documents

### DIFF
--- a/src/XamlStyler.Extension.Windows.VS2019/XamlStyler.Package.vsct
+++ b/src/XamlStyler.Extension.Windows.VS2019/XamlStyler.Package.vsct
@@ -35,12 +35,9 @@
       <Group guid="GuidXamlStylerMenuSet" id="GroupIDXamlStylerMenu" priority="0x0001">
         <Parent guid="GuidVisualStudioXAMLWindowContextMenu" id="IDVisualStudioXAMLWindowContextMenu"/>
       </Group>
-      <Group guid="GuidXamlStylerMenuSet" id="GroupIDXamlStylerMenu" priority="0x0001">
+      <!--<Group guid="GuidXamlStylerMenuSet" id="GroupIDXamlStylerMenu" priority="0x0001">
         <Parent guid="GuidVisualStudioXamarWindowContextMenu" id="IDVisualStudioXamarinWindowContextMenu"/>
-      </Group>
-      <Group guid="GuidXamlStylerMenuSet" id="GroupIDXamlStylerContextDocumentTabGroup" priority="0x0100">
-        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_EZDOCWINTAB" />
-      </Group>
+      </Group>-->
 
       <Group guid="GuidXamlStylerMenuSet" id="GroupIDXamlStylerContextSolutionNodeGroup" priority="0x0100">
         <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_SOLNNODE" />
@@ -132,9 +129,6 @@
   <CommandPlacements>
     <CommandPlacement guid="GuidXamlStylerMenuSet" id="CommandIDFormatXamlFile" priority="0x0100">
       <Parent guid="GuidXamlStylerMenuSet" id="GroupIDXamlStylerMenu" />
-    </CommandPlacement>
-    <CommandPlacement guid="GuidXamlStylerMenuSet" id="CommandIDFormatXamlFile" priority="0x0200">
-      <Parent guid="GuidXamlStylerMenuSet" id="GroupIDXamlStylerContextDocumentTabGroup" />
     </CommandPlacement>
 
     <CommandPlacement guid="GuidXamlStylerMenuSet" id="CommandIDFormatAllXaml" priority="0x0200">
@@ -235,9 +229,6 @@
       <IDSymbol name="GroupIDXamlStylerContextCrossProjectMultiSolutionFolderGroup" value="0x105a" />
       <IDSymbol name="GroupIDXamlStylerContextCrossProjectMultiProjectFolderGroup" value="0x105b" />
 
-      <!-- This is the command set for the document tab context menu -->
-      <IDSymbol name="GroupIDXamlStylerContextDocumentTabGroup" value="0x1070" />
-      
       <!-- These are the symbols for the individual commands -->
       <IDSymbol name="CommandIDFormatXamlFile" value="0x0100" />
       <IDSymbol name="CommandIDFormatAllXaml" value="0x0200" />

--- a/src/XamlStyler.Extension.Windows.VS2019/XamlStyler.Package.vsct
+++ b/src/XamlStyler.Extension.Windows.VS2019/XamlStyler.Package.vsct
@@ -35,9 +35,6 @@
       <Group guid="GuidXamlStylerMenuSet" id="GroupIDXamlStylerMenu" priority="0x0001">
         <Parent guid="GuidVisualStudioXAMLWindowContextMenu" id="IDVisualStudioXAMLWindowContextMenu"/>
       </Group>
-      <!--<Group guid="GuidXamlStylerMenuSet" id="GroupIDXamlStylerMenu" priority="0x0001">
-        <Parent guid="GuidVisualStudioXamarWindowContextMenu" id="IDVisualStudioXamarinWindowContextMenu"/>
-      </Group>-->
 
       <Group guid="GuidXamlStylerMenuSet" id="GroupIDXamlStylerContextSolutionNodeGroup" priority="0x0100">
         <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_SOLNNODE" />
@@ -173,7 +170,6 @@
   <!-- Visibility Constraints -->
   <VisibilityConstraints>
     <VisibilityItem context="GuidVisualStudioXAMLWindowContextMenu" guid="GuidXamlStylerMenuSet" id="CommandIDFormatXamlFile"/>
-    <VisibilityItem context="GuidVisualStudioXamarWindowContextMenu" guid="GuidXamlStylerMenuSet" id="CommandIDFormatXamlFile"/>
   </VisibilityConstraints>
   
   <!-- Keyboard Shortcuts -->
@@ -202,9 +198,6 @@
     -->
     <GuidSymbol name="GuidVisualStudioXAMLWindowContextMenu" value="{4C87B692-1202-46AA-B64C-EF01FAEC53DA}">
       <IDSymbol name="IDVisualStudioXAMLWindowContextMenu" value="0x0103" />
-    </GuidSymbol>
-    <GuidSymbol name="GuidVisualStudioXamarWindowContextMenu" value="{D309F791-903F-11D0-9EFC-00A0C911004F}">
-      <IDSymbol name="IDVisualStudioXamarinWindowContextMenu" value="0x040D" />
     </GuidSymbol>
 
     <!-- This is the package guid. -->

--- a/src/XamlStyler.Extension.Windows.VS2022/XamlStyler.Package.vsct
+++ b/src/XamlStyler.Extension.Windows.VS2022/XamlStyler.Package.vsct
@@ -35,12 +35,6 @@
       <Group guid="GuidXamlStylerMenuSet" id="GroupIDXamlStylerMenu" priority="0x0001">
         <Parent guid="GuidVisualStudioXAMLWindowContextMenu" id="IDVisualStudioXAMLWindowContextMenu"/>
       </Group>
-      <!--<Group guid="GuidXamlStylerMenuSet" id="GroupIDXamlStylerMenu" priority="0x0001">
-        <Parent guid="GuidVisualStudioXamarWindowContextMenu" id="IDVisualStudioXamarinWindowContextMenu"/>
-      </Group>-->
-      <!--<Group guid="GuidXamlStylerMenuSet" id="GroupIDXamlStylerContextDocumentTabGroup" priority="0x0100">
-        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_EZDOCWINTAB" />
-      </Group>-->
 
       <Group guid="GuidXamlStylerMenuSet" id="GroupIDXamlStylerContextSolutionNodeGroup" priority="0x0100">
         <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_SOLNNODE" />
@@ -133,9 +127,6 @@
     <CommandPlacement guid="GuidXamlStylerMenuSet" id="CommandIDFormatXamlFile" priority="0x0100">
       <Parent guid="GuidXamlStylerMenuSet" id="GroupIDXamlStylerMenu" />
     </CommandPlacement>
-    <CommandPlacement guid="GuidXamlStylerMenuSet" id="CommandIDFormatXamlFile" priority="0x0200">
-      <Parent guid="GuidXamlStylerMenuSet" id="GroupIDXamlStylerContextDocumentTabGroup" />
-    </CommandPlacement>
 
     <CommandPlacement guid="GuidXamlStylerMenuSet" id="CommandIDFormatAllXaml" priority="0x0200">
       <Parent guid="GuidXamlStylerMenuSet" id="GroupIDXamlStylerContextSolutionNodeGroup" />
@@ -179,7 +170,6 @@
   <!-- Visibility Constraints -->
   <VisibilityConstraints>
     <VisibilityItem context="GuidVisualStudioXAMLWindowContextMenu" guid="GuidXamlStylerMenuSet" id="CommandIDFormatXamlFile"/>
-    <!--<VisibilityItem context="GuidVisualStudioXamarWindowContextMenu" guid="GuidXamlStylerMenuSet" id="CommandIDFormatXamlFile"/>-->
   </VisibilityConstraints>
   
   <!-- Keyboard Shortcuts -->
@@ -209,9 +199,6 @@
     <GuidSymbol name="GuidVisualStudioXAMLWindowContextMenu" value="{4C87B692-1202-46AA-B64C-EF01FAEC53DA}">
       <IDSymbol name="IDVisualStudioXAMLWindowContextMenu" value="0x0103" />
     </GuidSymbol>
-    <!--<GuidSymbol name="GuidVisualStudioXamarWindowContextMenu" value="{D309F791-903F-11D0-9EFC-00A0C911004F}">
-      <IDSymbol name="IDVisualStudioXamarinWindowContextMenu" value="0x040D" />
-    </GuidSymbol>-->
 
     <!-- This is the package guid. -->
     <GuidSymbol name="GuidXamlStylerPackage" value="{a224be3c-88d1-4a57-9804-181dbef68021}" />
@@ -235,9 +222,6 @@
       <IDSymbol name="GroupIDXamlStylerContextCrossProjectMultiSolutionFolderGroup" value="0x105a" />
       <IDSymbol name="GroupIDXamlStylerContextCrossProjectMultiProjectFolderGroup" value="0x105b" />
 
-      <!-- This is the command set for the document tab context menu -->
-      <IDSymbol name="GroupIDXamlStylerContextDocumentTabGroup" value="0x1070" />
-      
       <!-- These are the symbols for the individual commands -->
       <IDSymbol name="CommandIDFormatXamlFile" value="0x0100" />
       <IDSymbol name="CommandIDFormatAllXaml" value="0x0200" />

--- a/src/XamlStyler.Extension.Windows.VS2022/XamlStyler.Package.vsct
+++ b/src/XamlStyler.Extension.Windows.VS2022/XamlStyler.Package.vsct
@@ -35,12 +35,12 @@
       <Group guid="GuidXamlStylerMenuSet" id="GroupIDXamlStylerMenu" priority="0x0001">
         <Parent guid="GuidVisualStudioXAMLWindowContextMenu" id="IDVisualStudioXAMLWindowContextMenu"/>
       </Group>
-      <Group guid="GuidXamlStylerMenuSet" id="GroupIDXamlStylerMenu" priority="0x0001">
+      <!--<Group guid="GuidXamlStylerMenuSet" id="GroupIDXamlStylerMenu" priority="0x0001">
         <Parent guid="GuidVisualStudioXamarWindowContextMenu" id="IDVisualStudioXamarinWindowContextMenu"/>
-      </Group>
-      <Group guid="GuidXamlStylerMenuSet" id="GroupIDXamlStylerContextDocumentTabGroup" priority="0x0100">
+      </Group>-->
+      <!--<Group guid="GuidXamlStylerMenuSet" id="GroupIDXamlStylerContextDocumentTabGroup" priority="0x0100">
         <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_EZDOCWINTAB" />
-      </Group>
+      </Group>-->
 
       <Group guid="GuidXamlStylerMenuSet" id="GroupIDXamlStylerContextSolutionNodeGroup" priority="0x0100">
         <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_SOLNNODE" />
@@ -179,7 +179,7 @@
   <!-- Visibility Constraints -->
   <VisibilityConstraints>
     <VisibilityItem context="GuidVisualStudioXAMLWindowContextMenu" guid="GuidXamlStylerMenuSet" id="CommandIDFormatXamlFile"/>
-    <VisibilityItem context="GuidVisualStudioXamarWindowContextMenu" guid="GuidXamlStylerMenuSet" id="CommandIDFormatXamlFile"/>
+    <!--<VisibilityItem context="GuidVisualStudioXamarWindowContextMenu" guid="GuidXamlStylerMenuSet" id="CommandIDFormatXamlFile"/>-->
   </VisibilityConstraints>
   
   <!-- Keyboard Shortcuts -->
@@ -209,9 +209,9 @@
     <GuidSymbol name="GuidVisualStudioXAMLWindowContextMenu" value="{4C87B692-1202-46AA-B64C-EF01FAEC53DA}">
       <IDSymbol name="IDVisualStudioXAMLWindowContextMenu" value="0x0103" />
     </GuidSymbol>
-    <GuidSymbol name="GuidVisualStudioXamarWindowContextMenu" value="{D309F791-903F-11D0-9EFC-00A0C911004F}">
+    <!--<GuidSymbol name="GuidVisualStudioXamarWindowContextMenu" value="{D309F791-903F-11D0-9EFC-00A0C911004F}">
       <IDSymbol name="IDVisualStudioXamarinWindowContextMenu" value="0x040D" />
-    </GuidSymbol>
+    </GuidSymbol>-->
 
     <!-- This is the package guid. -->
     <GuidSymbol name="GuidXamlStylerPackage" value="{a224be3c-88d1-4a57-9804-181dbef68021}" />


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->

### Description:

Fixes #132 (issue)

<!-- Please include a summary of your changes. Provide enough information so that others can review your pull request. -->

This removes unneeded and incorrect VSCT entries for the "Format XAML" context menu option.

- Removes from "IDM_VS_CTXT_EZDOCWINTAB" as this is the group in the ActiveDocument.
- Removes from "DVisualStudioXamarinWindowContextMenu" (Symbol `0x040D` of the "VS Main Menu") - I can't find a definition 
- This leaves the entry to add the group in the XAML Window context menu -- which is what is wanted and all that is needed.

I assume the "Xamarin" entry was added for a special case (in an earlier version of VS) that no longer applies.


### Checklist:
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] I have tested my changes by running the extension in VS2017
* [x] I have tested my changes by running the extension in VS2019
* [x] I have tested my changes by running the extension in VS2022
* [ ] If changes to the [documentation](https://github.com/Xavalon/XamlStyler/wiki) are needed, I have noted this in the description above
