### PR TITLE
Fix entry in About window

### DIFF
--- a/src/XamlStyler.Extension.Windows.Shared/StylerPackage.cs
+++ b/src/XamlStyler.Extension.Windows.Shared/StylerPackage.cs
@@ -23,7 +23,7 @@ namespace Xavalon.XamlStyler.Extension.Windows
 {
     [ProvideLoadKey("Standard", "2.1", "XAML Styler", "Xavalon", 104)]
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-    [InstalledProductRegistration("#1110", "#1112", "1.0", IconResourceID = 1400)] // Info on this package for Help/About
+    [InstalledProductRegistration("#1110", "#1112", "3.1", IconResourceID = 1400)] // Info on this package for Help/About
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [Guid(Guids.GuidXamlStylerPackageString)]
     [ProvideService(typeof(StylerService), IsAsyncQueryable = true)]

--- a/src/XamlStyler.Extension.Windows.Shared/VSPackage.resx
+++ b/src/XamlStyler.Extension.Windows.Shared/VSPackage.resx
@@ -135,13 +135,13 @@
   <data name="112" xml:space="preserve">
     <value>XAML Styler.</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="1110" xml:space="preserve">
-    <value>StylerPackage Extension</value>
+    <value>XAML Styler</value>
   </data>
   <data name="1112" xml:space="preserve">
-    <value>StylerPackage Visual Stuido Extension Detailed Info</value>
+    <value>XAML Styler is a visual studio extension that formats XAML source code based on a set of styling rules. This tool can help you/your team maintain a better XAML coding style as well as a much better XAML readability.</value>
   </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="1400" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\XamlStyler.Extension.Windows.Shared\Resources\StylerPackage.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->

### Description:

Fixes #471

<!-- Please include a summary of your changes. Provide enough information so that others can review your pull request. -->

Correct the output as shown in the Visual Studio, Help > About window

It now looks like this:
Details copied from the VSIX Manifest

![image](https://github.com/Xavalon/XamlStyler/assets/189547/bba39708-265e-42a7-832c-333be9ff1bee)


### Checklist:
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] I have tested my changes by running the extension in VS2017
* [x] I have tested my changes by running the extension in VS2019
* [x] I have tested my changes by running the extension in VS2022
* [ ] If changes to the [documentation](https://github.com/Xavalon/XamlStyler/wiki) are needed, I have noted this in the description above
