### PR TITLE
Removes unnecessary install targets from VS2017/2019 manifest

### DIFF
--- a/src/XamlStyler.Extension.Windows.VS2019/source.extension.vsixmanifest
+++ b/src/XamlStyler.Extension.Windows.VS2019/source.extension.vsixmanifest
@@ -13,8 +13,6 @@
     </Metadata>
     <!-- Visual Studio extensions and version ranges demystified: https://devblogs.microsoft.com/visualstudio/visual-studio-extensions-and-version-ranges-demystified/ -->
     <Installation AllUsers="true">
-        <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
-        <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
         <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Community" />
     </Installation>
     <Dependencies>


### PR DESCRIPTION
### Description:

Removes unnecessary install targets from VS2017/2019 manifest. See #482 for more details.

### Checklist:
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] I have tested my changes by running the extension in VS2017
* [x] I have tested my changes by running the extension in VS2019
* [ ] I have tested my changes by running the extension in VS2022
* [ ] If changes to the [documentation](https://github.com/Xavalon/XamlStyler/wiki) are needed, I have noted this in the description above
