### PR TITLE
Migrate to jetbrains platform 2.0.1

### DIFF
--- a/src/XamlStyler.Extension.Rider/build.gradle
+++ b/src/XamlStyler.Extension.Rider/build.gradle
@@ -6,26 +6,37 @@ plugins {
 
     // RIDER: May need updating with new Rider releases
     id 'org.jetbrains.kotlin.jvm' version '1.9.10'
-    id 'com.jetbrains.rdgen' version '2023.2.0'
+    id 'com.jetbrains.rdgen' version '2024.1.1'
 
     // RIDER: Will probably need updating with new Rider releases, use latest version number from https://github.com/JetBrains/gradle-intellij-plugin/releases
-    id 'org.jetbrains.intellij' version '1.17.4'
+    id 'org.jetbrains.intellij.platform' version '2.0.1'
 }
 
 ext {
     isWindows = Os.isFamily(Os.FAMILY_WINDOWS)
     rdLibDirectory = {
-        new File(setupDependencies.idea.get().classes, "lib/rd")
+        new File(intellijPlatform.platformPath.resolve("lib/rd/").toAbsolutePath().toString())
     }
 }
 
 repositories {
     maven { url 'https://cache-redirector.jetbrains.com/intellij-repository/snapshots' }
     maven { url 'https://cache-redirector.jetbrains.com/maven-central' }
+    intellijPlatform {
+        defaultRepositories()
+        jetbrainsRuntime()
+    }
+}
+
+dependencies {
+  intellijPlatform {
+    rider("${ProductVersion}")
+    jetbrainsRuntime()
+  }
 }
 
 wrapper {
-    gradleVersion = '8.5'
+    gradleVersion = '8.10'
     distributionType = Wrapper.DistributionType.ALL
     distributionUrl = "https://cache-redirector.jetbrains.com/services.gradle.org/distributions/gradle-${gradleVersion}-all.zip"
 }
@@ -75,10 +86,7 @@ buildPlugin {
     }
 }
 
-intellij {
-    type = 'RD'
-    version = "${ProductVersion}"
-    downloadSources = false
+intellijPlatform {
     instrumentCode = false
 }
 
@@ -88,7 +96,7 @@ runIde {
 
     // Rider's backend doesn't support dynamic plugins. It might be possible to work with auto-reload of the frontend
     // part of a plugin, but there are dangers about keeping plugins in sync
-    autoReloadPlugins = false
+    autoReload = false
 
     // gradle-intellij-plugin will download the default version of the JBR for the snapshot. Update if required
     // jbrVersion = "jbr_jcef-11_0_6b765.40" // https://confluence.jetbrains.com/display/JBR/Release+notes

--- a/src/XamlStyler.Extension.Rider/gradle/wrapper/gradle-wrapper.properties
+++ b/src/XamlStyler.Extension.Rider/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://cache-redirector.jetbrains.com/services.gradle.org/distributions/gradle-7.6-all.zip
+distributionUrl=https\://cache-redirector.jetbrains.com/services.gradle.org/distributions/gradle-8.10-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->

### Description:

Fixes https://github.com/Xavalon/XamlStyler/issues/500

Migrate to [IntelliJ Platform Gradle Plugin (2.x)](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html#0)

Notes: 

- This is the first time that I see JetBrains plugin code. I made the changes following the [migration guide](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-migration.html), but I added some extra code that I saw in other Rider plugins, which maybe wasn't necessary, this code is added when I tried to download rider-model.jar.
- It doesn't automatically download the rider-model.jar and rd-gen.jar, so I downloaded them manually [here](https://www.jetbrains.com/intellij-repository/snapshots) and replaced them in the directory that the error showed when building (some gradlew cache folder).
- I successful build it and test it on Rider 2024.2.3 (#RD-242.21829.166) using "[com.jetbrains.intellij.rider 2024.2-RC1-SNAPSHOT](https://www.jetbrains.com/intellij-repository/snapshots/com/jetbrains/intellij/rider/riderRD/2024.2-RC1-SNAPSHOT/riderRD-2024.2-RC1-SNAPSHOT.zip)"

<!-- Please include a summary of your changes. Provide enough information so that others can review your pull request. -->

### Checklist:
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] I have tested my changes by running the extension in VS2017
* [ ] I have tested my changes by running the extension in VS2019
* [ ] I have tested my changes by running the extension in VS2022
* [ ] If changes to the [documentation](https://github.com/Xavalon/XamlStyler/wiki) are needed, I have noted this in the description above
