### PR TITLE
Added readme file to XamlStyler.Console (fixes #505)

### DIFF
--- a/src/XamlStyler.Console/README.md
+++ b/src/XamlStyler.Console/README.md
@@ -1,0 +1,14 @@
+# XAML Styler Console
+
+The power of XAML Styler wrapped up in a small executable that can be integrated into build scripts, git commit templates, and more.
+
+XAML Styler is a visual studio extension that formats XAML source code based on a set of styling rules. This tool can help you/your team maintain a better XAML coding style as well as a much better XAML readability.
+
+This package is built on top of the same styling engine that powers the Visual Studio plugin, and can be configured by specifying an external configuration.
+
+**Using Visual Studio 2022?** [Download XAML Styler for Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=TeamXavalon.XAMLStyler2022)
+
+**Using Visual Studio 2017 or 2019?** [Download XAML Styler](https://marketplace.visualstudio.com/items?itemName=TeamXavalon.XAMLStyler)
+
+|[Documentation](https://github.com/Xavalon/XamlStyler/wiki)|[Script Integration](https://github.com/Xavalon/XamlStyler/wiki/Script-Integration)|[Release Notes](https://github.com/Xavalon/XamlStyler/releases)|[Contributing](https://github.com/Xavalon/XamlStyler/blob/master/CONTRIBUTING.md)|
+|---|---|---|---|

--- a/src/XamlStyler.Console/XamlStyler.Console.csproj
+++ b/src/XamlStyler.Console/XamlStyler.Console.csproj
@@ -21,6 +21,7 @@
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OutputPath>..\bin\Debug\Console\</OutputPath>
@@ -46,5 +47,11 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\XamlStyler\XamlStyler.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Description:

Fixes #505 

This PR adds a readme file to the NuGet package as suggest by the [best practices site](https://learn.microsoft.com/en-us/nuget/create-packages/package-authoring-best-practices#readme).


### Checklist:
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] I have tested my changes by running the extension in VS2017
* [ ] I have tested my changes by running the extension in VS2019
* [ ] I have tested my changes by running the extension in VS2022
* [ ] If changes to the [documentation](https://github.com/Xavalon/XamlStyler/wiki) are needed, I have noted this in the description above
