### PR TITLE
Added targets for net6.0 and net8.0 and allow RollForward

### DIFF
--- a/build/pipelines/templates/build-console-public.yaml
+++ b/build/pipelines/templates/build-console-public.yaml
@@ -19,7 +19,12 @@ jobs:
     inputs:
       packageType: sdk
       version: 6.0.x
-      installationPath: $(Agent.ToolsDirectory)/dotnet
+      
+  - task: UseDotNet@2
+    displayName: 'Use .NET 8 SDK'
+    inputs:
+      packageType: sdk
+      version: 8.0.x
 
   # The first task is the dotnet command build, pointing to our csproj file
   - task: DotNetCoreCLI@2

--- a/build/pipelines/templates/build-extension-public.yaml
+++ b/build/pipelines/templates/build-extension-public.yaml
@@ -19,7 +19,19 @@ jobs:
       filePath: 'build\update-version.ps1'
       arguments: $(major).$(Get-Date -Format "yyMM").$(patch)
       pwsh: true
+
+  - task: UseDotNet@2
+    displayName: 'Use .NET 6 SDK'
+    inputs:
+      packageType: sdk
+      version: 6.0.x
       
+  - task: UseDotNet@2
+    displayName: 'Use .NET 8 SDK'
+    inputs:
+      packageType: sdk
+      version: 8.0.x
+
   - task: NuGetToolInstaller@1
     displayName: 'Install NuGet Tools'
 

--- a/src/XamlStyler.Console/XamlStyler.Console.csproj
+++ b/src/XamlStyler.Console/XamlStyler.Console.csproj
@@ -13,7 +13,7 @@
     <RepositoryUrl>https://github.com/Xavalon/XamlStyler</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <OutputType>Exe</OutputType>
-	<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <RootNamespace>Xavalon.XamlStyler.Console</RootNamespace>
     <AssemblyName>xstyler</AssemblyName>
     <PackAsTool>true</PackAsTool>
@@ -21,9 +21,9 @@
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
-	<RollForward>Major</RollForward>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OutputPath>..\bin\Debug\Console\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/XamlStyler.Console/XamlStyler.Console.csproj
+++ b/src/XamlStyler.Console/XamlStyler.Console.csproj
@@ -13,7 +13,7 @@
     <RepositoryUrl>https://github.com/Xavalon/XamlStyler</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+	<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <RootNamespace>Xavalon.XamlStyler.Console</RootNamespace>
     <AssemblyName>xstyler</AssemblyName>
     <PackAsTool>true</PackAsTool>
@@ -21,8 +21,9 @@
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
+	<RollForward>Major</RollForward>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OutputPath>..\bin\Debug\Console\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
+++ b/src/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <RootNamespace>Xavalon.XamlStyler.UnitTests</RootNamespace>
     <Copyright>Copyright © Xavalon 2024</Copyright>
     <Company>Xavalon</Company>


### PR DESCRIPTION
### Description:

Fixes #447 
Fixes #495 

This PR adds the TargetFrameworks net6.0 and net8.0.
Also as sugegsted in #419 the RollForward property was added.

I'm not sure about the piepline configurations, but adjusted them according to #419 

### Checklist:
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] I have tested my changes by running the extension in VS2017
* [x] I have tested my changes by running the extension in VS2019
* [x] I have tested my changes by running the extension in VS2022
* [x] If changes to the [documentation](https://github.com/Xavalon/XamlStyler/wiki) are needed, I have noted this in the description above
