### PR TITLE
Remove dependency on `NuGet.CommandLine` (fixes #508)

### DIFF
--- a/src/XamlStyler.Console/XamlStyler.Console.csproj
+++ b/src/XamlStyler.Console/XamlStyler.Console.csproj
@@ -35,11 +35,6 @@
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>
     </PackageReference>
-    <PackageReference Include="NuGet.CommandLine">
-      <Version>6.8.0</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\icon.jpg" Pack="true" PackagePath="\" />


### PR DESCRIPTION
### Description:

Fixes #508 

This PR removes the dependency on `NuGet.CommandLine`.
I found no reference to this dependency and therefor I removed it completely.

### Checklist:
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] I have tested my changes by running the extension in VS2017
* [ ] I have tested my changes by running the extension in VS2019
* [x] I have tested my changes by running the extension in VS2022
* [x] If changes to the [documentation](https://github.com/Xavalon/XamlStyler/wiki) are needed, I have noted this in the description above
