### PR TITLE
AllowRollForward and update unsafe nuget package

### DIFF
--- a/src/XamlStyler.Console/XamlStyler.Console.csproj
+++ b/src/XamlStyler.Console/XamlStyler.Console.csproj
@@ -21,6 +21,7 @@
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OutputPath>..\bin\Debug\Console\</OutputPath>
@@ -36,7 +37,7 @@
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="NuGet.CommandLine">
-      <Version>6.8.0</Version>
+      <Version>6.12.2</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/XamlStyler.Extension.Windows.VS2019/XamlStyler.Extension.Windows.VS2019.csproj
+++ b/src/XamlStyler.Extension.Windows.VS2019/XamlStyler.Extension.Windows.VS2019.csproj
@@ -90,7 +90,7 @@
       <Version>4.83.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
-      <Version>8.0.0</Version>
+      <Version>9.0.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/XamlStyler.Extension.Windows.VS2022/XamlStyler.Extension.Windows.VS2022.csproj
+++ b/src/XamlStyler.Extension.Windows.VS2022/XamlStyler.Extension.Windows.VS2022.csproj
@@ -90,7 +90,7 @@
       <Version>4.83.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
-      <Version>8.0.0</Version>
+      <Version>9.0.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
+++ b/src/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
@@ -28,16 +28,16 @@
 <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.83.0">
     </PackageReference>
-    <PackageReference Include="Irony" Version="1.2.0">
+    <PackageReference Include="Irony" Version="1.5.3">
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3">
     </PackageReference>
-    <PackageReference Include="NUnit" Version="4.0.1">
+    <PackageReference Include="NUnit" Version="4.3.2">
     </PackageReference>
-    <PackageReference Include="NUnit.ConsoleRunner" Version="3.16.3">
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.19.0">
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
     </PackageReference>
   </ItemGroup>
 <ItemGroup>

--- a/src/XamlStyler/XamlStyler.csproj
+++ b/src/XamlStyler/XamlStyler.csproj
@@ -25,7 +25,7 @@
     <EmbeddedResource Include="Options\DefaultSettings.json" />
   </ItemGroup>
 <ItemGroup>
-    <PackageReference Include="Irony" Version="1.2.0">
+    <PackageReference Include="Irony" Version="1.5.3">
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1">
     </PackageReference>


### PR DESCRIPTION
- Update nuggets 
  except newton.json and vs related
- AllowRollForward so that we can run in new dotnet version

<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->

### Description:

Fixes #447 #495

<!-- Please include a summary of your changes. Provide enough information so that others can review your pull request. -->

### Checklist:
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] I have tested my changes by running the extension in VS2017
* [x] I have tested my changes by running the extension in VS2019
* [x] I have tested my changes by running the extension in VS2022
* [x] If changes to the [documentation](https://github.com/Xavalon/XamlStyler/wiki) are needed, I have noted this in the description above
