### PR TITLE
Optimize CI builds to limit impact of Rider build

### DIFF
--- a/build/pipelines/azure-pipelines.ci.yml
+++ b/build/pipelines/azure-pipelines.ci.yml
@@ -9,7 +9,7 @@ variables:
   buildConfiguration: 'Release'
   major: 0
   patch: $[counter(format('{0:yyMM}', pipeline.startTime), 0)]
-  skipBuildRiderExtensionJob: false
+  checkRiderChanges: true
 
 name: $(major).$(Date:yyMM).$(patch).0
 

--- a/build/pipelines/azure-pipelines.ci.yml
+++ b/build/pipelines/azure-pipelines.ci.yml
@@ -9,7 +9,7 @@ variables:
   buildConfiguration: 'Release'
   major: 0
   patch: $[counter(format('{0:yyMM}', pipeline.startTime), 0)]
-  skipBuildRiderExtensionJob: true
+  skipBuildRiderExtensionJob: false
 
 name: $(major).$(Date:yyMM).$(patch).0
 

--- a/build/pipelines/azure-pipelines.ci.yml
+++ b/build/pipelines/azure-pipelines.ci.yml
@@ -9,6 +9,7 @@ variables:
   buildConfiguration: 'Release'
   major: 0
   patch: $[counter(format('{0:yyMM}', pipeline.startTime), 0)]
+  skipBuildRiderExtensionJob: true
 
 name: $(major).$(Date:yyMM).$(patch).0
 

--- a/build/pipelines/azure-pipelines.release.yml
+++ b/build/pipelines/azure-pipelines.release.yml
@@ -12,6 +12,7 @@ variables:
   buildConfiguration: 'Release'
   major: 3
   patch: $[counter(format('{0:yyMM}', pipeline.startTime), 0)]
+  skipBuildRiderExtensionJob: false
 
 name: $(major).$(Date:yyMM).$(patch).0
 

--- a/build/pipelines/azure-pipelines.release.yml
+++ b/build/pipelines/azure-pipelines.release.yml
@@ -12,7 +12,7 @@ variables:
   buildConfiguration: 'Release'
   major: 3
   patch: $[counter(format('{0:yyMM}', pipeline.startTime), 0)]
-  skipBuildRiderExtensionJob: false
+  checkRiderChanges: false
 
 name: $(major).$(Date:yyMM).$(patch).0
 

--- a/build/pipelines/templates/build-extension-rider-public.yaml
+++ b/build/pipelines/templates/build-extension-rider-public.yaml
@@ -23,12 +23,12 @@ jobs:
         $changedFiles = git diff HEAD HEAD~ --name-only -- $folderPath
 
         if ($changedFiles.Count -gt 0) {
-          Write-Host "Changes detected in $folderPath:"
+          Write-Host "Changes detected in {0}:" -f $folderPath
           $changedFiles | ForEach-Object { Write-Host $_ }
           # Set a variable to indicate changes
           Write-Host "##vso[task.setvariable variable=ChangesDetected;isOutput=true]true"
         } else {
-          Write-Host "No changes detected in $folderPath"
+          Write-Host "No changes detected in {0}" -f $folderPath
           # Set a variable to indicate no changes
           Write-Host "##vso[task.setvariable variable=ChangesDetected;isOutput=true]false"
         }

--- a/build/pipelines/templates/build-extension-rider-public.yaml
+++ b/build/pipelines/templates/build-extension-rider-public.yaml
@@ -21,7 +21,7 @@ jobs:
       script: |
         #$folderPath = '**/XamlStyler.Extension.Rider/*'
         $folderPath = '**/pipelines/*'
-        $changedFiles = git diff master --name-only -- $folderPath
+        $changedFiles = git diff e5828a952db379553a6ea181d06c1890f36f4cd9 --name-only -- $folderPath
 
         if ($changedFiles.Count -gt 0) {
           Write-Host "Changes detected in Rider project:"

--- a/build/pipelines/templates/build-extension-rider-public.yaml
+++ b/build/pipelines/templates/build-extension-rider-public.yaml
@@ -11,7 +11,10 @@ jobs:
 
   continueOnError: true
 
-  steps:      
+  steps:
+  - checkout: self
+      fetchDepth: 0
+
   - task: PowerShell@2
     displayName: 'Check for Rider project changes'
     condition: eq(variables['checkRiderChanges'], true)

--- a/build/pipelines/templates/build-extension-rider-public.yaml
+++ b/build/pipelines/templates/build-extension-rider-public.yaml
@@ -21,7 +21,7 @@ jobs:
       script: |
         #$folderPath = '**/XamlStyler.Extension.Rider/*'
         $folderPath = '**/pipelines/*'
-        $changedFiles = git diff master...HEAD --name-only -- $folderPath
+        $changedFiles = git diff master --name-only -- $folderPath
 
         if ($changedFiles.Count -gt 0) {
           Write-Host "Changes detected in Rider project:"

--- a/build/pipelines/templates/build-extension-rider-public.yaml
+++ b/build/pipelines/templates/build-extension-rider-public.yaml
@@ -22,7 +22,7 @@ jobs:
         #$folderPath = '**/XamlStyler.Extension.Rider/*'
         $folderPath = '**/pipelines/*'
         git show-ref
-        $changedFiles = git diff e5828a952db379553a6ea181d06c1890f36f4cd9 --name-only -- $folderPath
+        $changedFiles = git diff refs/remotes/origin/master --name-only -- $folderPath
 
         if ($changedFiles.Count -gt 0) {
           Write-Host "Changes detected in Rider project:"

--- a/build/pipelines/templates/build-extension-rider-public.yaml
+++ b/build/pipelines/templates/build-extension-rider-public.yaml
@@ -3,7 +3,7 @@ jobs:
 
   displayName: 'Build Rider Plugin'
 
-  condition: false
+  condition: $(skipBuildRiderExtensionJob)
 
   pool:
     vmImage: 'windows-latest'

--- a/build/pipelines/templates/build-extension-rider-public.yaml
+++ b/build/pipelines/templates/build-extension-rider-public.yaml
@@ -13,7 +13,7 @@ jobs:
 
   steps:
   - checkout: self
-      fetchDepth: 0
+    fetchDepth: 0
 
   - task: PowerShell@2
     displayName: 'Check for Rider project changes'

--- a/build/pipelines/templates/build-extension-rider-public.yaml
+++ b/build/pipelines/templates/build-extension-rider-public.yaml
@@ -3,8 +3,6 @@ jobs:
 
   displayName: 'Build Rider Plugin'
 
-  condition: eq(variables['skipBuildRiderExtensionJob'], false)
-
   pool:
     vmImage: 'windows-latest'
 
@@ -14,6 +12,10 @@ jobs:
   continueOnError: true
 
   steps:      
+  - task: PowerShell@2
+    displayName: 'Check for Rider project changes'
+    condition: $(checkRiderChanges)
+  
   - task: NuGetToolInstaller@1
     displayName: 'Install NuGet Tools'
 

--- a/build/pipelines/templates/build-extension-rider-public.yaml
+++ b/build/pipelines/templates/build-extension-rider-public.yaml
@@ -20,15 +20,16 @@ jobs:
       pwsh: true
       script: |
         $folderPath = '**/XamlStyler.Extension.Rider/*'
-        $changedFiles = git diff HEAD HEAD~ --name-only -- $folderPath
+        $changedFiles = git diff master..HEAD --name-only -- $folderPath
 
         if ($changedFiles.Count -gt 0) {
-          Write-Host "Changes detected:"
+          Write-Host "Changes detected in Rider project:"
           $changedFiles | ForEach-Object { Write-Host $_ }
           # Set a variable to indicate changes
           Write-Host "##vso[task.setvariable variable=ChangesDetected;isOutput=true]true"
         } else {
-          Write-Host "No changes detected"
+          Write-Host "No changes detected in Rider project:"
+          $changedFiles | ForEach-Object { Write-Host $_ }
           # Set a variable to indicate no changes
           Write-Host "##vso[task.setvariable variable=ChangesDetected;isOutput=true]false"
         }

--- a/build/pipelines/templates/build-extension-rider-public.yaml
+++ b/build/pipelines/templates/build-extension-rider-public.yaml
@@ -14,7 +14,7 @@ jobs:
   steps:      
   - task: PowerShell@2
     displayName: 'Check for Rider project changes'
-    condition: $(checkRiderChanges)
+    condition: eq(variables['checkRiderChanges'], true)
   
   - task: NuGetToolInstaller@1
     displayName: 'Install NuGet Tools'

--- a/build/pipelines/templates/build-extension-rider-public.yaml
+++ b/build/pipelines/templates/build-extension-rider-public.yaml
@@ -20,7 +20,7 @@ jobs:
       targetType: 'inline'
       pwsh: true
       script: |
-        #$folderPath = '**/XamlStyler.Extension.Rider/*'
+        $folderPath = '**/XamlStyler.Extension.Rider/*'
 
         # For debugging pipeline
         #$folderPath = '**/pipelines/*'

--- a/build/pipelines/templates/build-extension-rider-public.yaml
+++ b/build/pipelines/templates/build-extension-rider-public.yaml
@@ -23,12 +23,12 @@ jobs:
         $changedFiles = git diff HEAD HEAD~ --name-only -- $folderPath
 
         if ($changedFiles.Count -gt 0) {
-          Write-Host "Changes detected in {0}:" -f $folderPath
+          Write-Host "Changes detected:"
           $changedFiles | ForEach-Object { Write-Host $_ }
           # Set a variable to indicate changes
           Write-Host "##vso[task.setvariable variable=ChangesDetected;isOutput=true]true"
         } else {
-          Write-Host "No changes detected in {0}" -f $folderPath
+          Write-Host "No changes detected"
           # Set a variable to indicate no changes
           Write-Host "##vso[task.setvariable variable=ChangesDetected;isOutput=true]false"
         }

--- a/build/pipelines/templates/build-extension-rider-public.yaml
+++ b/build/pipelines/templates/build-extension-rider-public.yaml
@@ -14,25 +14,29 @@ jobs:
   steps:
   - task: PowerShell@2
     displayName: 'Check for Rider project changes'
+    name: RiderProjectChanges
     condition: eq(variables['checkRiderChanges'], true)
     inputs:
       targetType: 'inline'
       pwsh: true
       script: |
-        $folderPath = '**/XamlStyler.Extension.Rider/*'
+        #$folderPath = '**/XamlStyler.Extension.Rider/*'
+
+        # For debugging pipeline
         #$folderPath = '**/pipelines/*'
-        git show-ref
+        #git show-ref
+        
         $changedFiles = git diff refs/remotes/origin/master --name-only -- $folderPath
 
         if ($changedFiles.Count -gt 0) {
           Write-Host "Changes detected in Rider project:"
           $changedFiles | ForEach-Object { Write-Host $_ }
           # Set a variable to indicate changes
-          Write-Host "##vso[task.setvariable variable=ChangesDetected;isOutput=true]true"
+          Write-Host "##vso[task.setvariable variable=ChangesDetected]true"
         } else {
           Write-Host "No changes detected in Rider project"
           # Set a variable to indicate no changes
-          Write-Host "##vso[task.setvariable variable=ChangesDetected;isOutput=true]false"
+          Write-Host "##vso[task.setvariable variable=ChangesDetected]false"
         }
   
   - task: NuGetToolInstaller@1

--- a/build/pipelines/templates/build-extension-rider-public.yaml
+++ b/build/pipelines/templates/build-extension-rider-public.yaml
@@ -3,7 +3,7 @@ jobs:
 
   displayName: 'Build Rider Plugin'
 
-  condition: $(skipBuildRiderExtensionJob)
+  condition: eq(variables['skipBuildRiderExtensionJob'], false)
 
   pool:
     vmImage: 'windows-latest'

--- a/build/pipelines/templates/build-extension-rider-public.yaml
+++ b/build/pipelines/templates/build-extension-rider-public.yaml
@@ -19,8 +19,8 @@ jobs:
       targetType: 'inline'
       pwsh: true
       script: |
-        #$folderPath = '**/XamlStyler.Extension.Rider/*'
-        $folderPath = '**/pipelines/*'
+        $folderPath = '**/XamlStyler.Extension.Rider/*'
+        #$folderPath = '**/pipelines/*'
         git show-ref
         $changedFiles = git diff refs/remotes/origin/master --name-only -- $folderPath
 
@@ -37,18 +37,18 @@ jobs:
   
   - task: NuGetToolInstaller@1
     displayName: 'Install NuGet Tools'
-    condition: eq(variables['ChangesDetected'], 'true')
+    condition: eq(variables['ChangesDetected'], true)
 
   - task: NuGetCommand@2
     displayName: 'NuGet Restore'
-    condition: eq(variables['ChangesDetected'], 'true')
+    condition: eq(variables['ChangesDetected'], true)
     inputs:
       command: custom
       arguments: restore src/XamlStyler.Rider.sln -Verbosity Detailed -NonInteractive
 
   - task: Gradle@2
     displayName: Build
-    condition: eq(variables['ChangesDetected'], 'true')
+    condition: eq(variables['ChangesDetected'], true)
     inputs:
       workingDirectory: '$(Pipeline.Workspace)\s\src\XamlStyler.Extension.Rider'
       gradleWrapperFile: '$(Pipeline.Workspace)\s\src\XamlStyler.Extension.Rider\gradlew.bat'
@@ -63,7 +63,7 @@ jobs:
 
   - task: CopyFiles@2
     displayName: Copy Artifacts to Staging
-    condition: eq(variables['ChangesDetected'], 'true')
+    condition: eq(variables['ChangesDetected'], true)
     inputs:
       contents: '$(Pipeline.Workspace)\s\src\XamlStyler.Extension.Rider\output\**\*.zip'
       targetFolder: $(Build.ArtifactStagingDirectory)
@@ -73,7 +73,7 @@ jobs:
 
   - task: PublishBuildArtifacts@1
     displayName: Publish artifacts
-    condition: eq(variables['ChangesDetected'], 'true')
+    condition: eq(variables['ChangesDetected'], true)
     inputs:
       pathToPublish: $(Build.ArtifactStagingDirectory)
       artifactName: 'XamlStyler.Extension.Rider'

--- a/build/pipelines/templates/build-extension-rider-public.yaml
+++ b/build/pipelines/templates/build-extension-rider-public.yaml
@@ -15,6 +15,11 @@ jobs:
   - task: PowerShell@2
     displayName: 'Check for Rider project changes'
     condition: eq(variables['checkRiderChanges'], true)
+    inputs:
+      targetType: 'inline'
+      pwsh: true
+      script: |
+        # PowerShell script to check for changes
   
   - task: NuGetToolInstaller@1
     displayName: 'Install NuGet Tools'

--- a/build/pipelines/templates/build-extension-rider-public.yaml
+++ b/build/pipelines/templates/build-extension-rider-public.yaml
@@ -21,6 +21,7 @@ jobs:
       script: |
         #$folderPath = '**/XamlStyler.Extension.Rider/*'
         $folderPath = '**/pipelines/*'
+        git show-ref
         $changedFiles = git diff e5828a952db379553a6ea181d06c1890f36f4cd9 --name-only -- $folderPath
 
         if ($changedFiles.Count -gt 0) {

--- a/build/pipelines/templates/build-extension-rider-public.yaml
+++ b/build/pipelines/templates/build-extension-rider-public.yaml
@@ -19,7 +19,8 @@ jobs:
       targetType: 'inline'
       pwsh: true
       script: |
-        $folderPath = '**/XamlStyler.Extension.Rider/*'
+        #$folderPath = '**/XamlStyler.Extension.Rider/*'
+        $folderPath = '**/pipelines/*'
         $changedFiles = git diff master..HEAD --name-only -- $folderPath
 
         if ($changedFiles.Count -gt 0) {
@@ -28,8 +29,7 @@ jobs:
           # Set a variable to indicate changes
           Write-Host "##vso[task.setvariable variable=ChangesDetected;isOutput=true]true"
         } else {
-          Write-Host "No changes detected in Rider project:"
-          $changedFiles | ForEach-Object { Write-Host $_ }
+          Write-Host "No changes detected in Rider project"
           # Set a variable to indicate no changes
           Write-Host "##vso[task.setvariable variable=ChangesDetected;isOutput=true]false"
         }

--- a/build/pipelines/templates/build-extension-rider-public.yaml
+++ b/build/pipelines/templates/build-extension-rider-public.yaml
@@ -3,6 +3,8 @@ jobs:
 
   displayName: 'Build Rider Plugin'
 
+  condition: false
+
   pool:
     vmImage: 'windows-latest'
 

--- a/build/pipelines/templates/build-extension-rider-public.yaml
+++ b/build/pipelines/templates/build-extension-rider-public.yaml
@@ -19,19 +19,34 @@ jobs:
       targetType: 'inline'
       pwsh: true
       script: |
-        # PowerShell script to check for changes
+        $folderPath = '**/XamlStyler.Extension.Rider/*'
+        $changedFiles = git diff HEAD HEAD~ --name-only -- $folderPath
+
+        if ($changedFiles.Count -gt 0) {
+          Write-Host "Changes detected in $folderPath:"
+          $changedFiles | ForEach-Object { Write-Host $_ }
+          # Set a variable to indicate changes
+          Write-Host "##vso[task.setvariable variable=ChangesDetected;isOutput=true]true"
+        } else {
+          Write-Host "No changes detected in $folderPath"
+          # Set a variable to indicate no changes
+          Write-Host "##vso[task.setvariable variable=ChangesDetected;isOutput=true]false"
+        }
   
   - task: NuGetToolInstaller@1
     displayName: 'Install NuGet Tools'
+    condition: eq(variables['ChangesDetected'], 'true')
 
   - task: NuGetCommand@2
     displayName: 'NuGet Restore'
+    condition: eq(variables['ChangesDetected'], 'true')
     inputs:
       command: custom
       arguments: restore src/XamlStyler.Rider.sln -Verbosity Detailed -NonInteractive
 
   - task: Gradle@2
     displayName: Build
+    condition: eq(variables['ChangesDetected'], 'true')
     inputs:
       workingDirectory: '$(Pipeline.Workspace)\s\src\XamlStyler.Extension.Rider'
       gradleWrapperFile: '$(Pipeline.Workspace)\s\src\XamlStyler.Extension.Rider\gradlew.bat'
@@ -46,6 +61,7 @@ jobs:
 
   - task: CopyFiles@2
     displayName: Copy Artifacts to Staging
+    condition: eq(variables['ChangesDetected'], 'true')
     inputs:
       contents: '$(Pipeline.Workspace)\s\src\XamlStyler.Extension.Rider\output\**\*.zip'
       targetFolder: $(Build.ArtifactStagingDirectory)
@@ -55,6 +71,7 @@ jobs:
 
   - task: PublishBuildArtifacts@1
     displayName: Publish artifacts
+    condition: eq(variables['ChangesDetected'], 'true')
     inputs:
       pathToPublish: $(Build.ArtifactStagingDirectory)
       artifactName: 'XamlStyler.Extension.Rider'

--- a/build/pipelines/templates/build-extension-rider-public.yaml
+++ b/build/pipelines/templates/build-extension-rider-public.yaml
@@ -12,9 +12,6 @@ jobs:
   continueOnError: true
 
   steps:
-  - checkout: self
-    fetchDepth: 0
-
   - task: PowerShell@2
     displayName: 'Check for Rider project changes'
     condition: eq(variables['checkRiderChanges'], true)
@@ -24,7 +21,7 @@ jobs:
       script: |
         #$folderPath = '**/XamlStyler.Extension.Rider/*'
         $folderPath = '**/pipelines/*'
-        $changedFiles = git diff master..HEAD --name-only -- $folderPath
+        $changedFiles = git diff master...HEAD --name-only -- $folderPath
 
         if ($changedFiles.Count -gt 0) {
           Write-Host "Changes detected in Rider project:"


### PR DESCRIPTION
### Description:

Optimizing CI pipeline so Rider is only built when there are changes to the Rider project. Rider builds can take up to 20 minutes to complete, compared to 3 minutes or less for other build jobs.

### Checklist:
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] I have tested my changes by running the extension in VS2017
* [ ] I have tested my changes by running the extension in VS2019
* [ ] I have tested my changes by running the extension in VS2022
* [ ] If changes to the [documentation](https://github.com/Xavalon/XamlStyler/wiki) are needed, I have noted this in the description above
