### PR TITLE
fix slight typo in command line options

### DIFF
--- a/src/XamlStyler.Console/Options.cs
+++ b/src/XamlStyler.Console/Options.cs
@@ -29,7 +29,7 @@ namespace Xavalon.XamlStyler.Console
         public bool IsPassive { get; set; }
 
         [Option("write-to-stdout", Default = false,
-            HelpText = "Instead of modifying the file, write to stdout. In this mode, logs are printed to stderr. Must specify exactly one file. Cannot be compbined with --passive.")]
+            HelpText = "Instead of modifying the file, write to stdout. In this mode, logs are printed to stderr. Must specify exactly one file. Cannot be combined with --passive.")]
         public bool WriteToStdout { get; set; }
 
         [Option('l', "loglevel", Default = LogLevel.Default,


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->

### Description:

Fixes # (issue)
There was a typo in the explanation message in  options for --write-to-stdout. I have corrected that

### Checklist:
* [*] I have commented my code, particularly in hard-to-understand areas
* [*] My changes generate no new warnings
* [*] I have added tests that prove my fix is effective or that my feature works
* [*] New and existing unit tests pass locally with my changes
* [*] I have tested my changes by running the extension in VS2017
* [*] I have tested my changes by running the extension in VS2019
* [*] I have tested my changes by running the extension in VS2022
* [*] If changes to the [documentation](https://github.com/Xavalon/XamlStyler/wiki) are needed, I have noted this in the description above
