### PR TITLE
Add options to preserve original element and attribute formatting

### DIFF
--- a/src/XamlStyler.UnitTests/FormatPreservationTests.cs
+++ b/src/XamlStyler.UnitTests/FormatPreservationTests.cs
@@ -1,0 +1,71 @@
+// (c) Xavalon. All rights reserved.
+
+using System;
+using NUnit.Framework;
+using Xavalon.XamlStyler;
+using Xavalon.XamlStyler.Options;
+
+namespace Xavalon.XamlStyler.UnitTests
+{
+    [TestFixture]
+    public class FormatPreservationTests
+    {
+        [Test]
+        public void KeepOriginalElementFormatPreservesSelfClosingAndEndTags()
+        {
+            var options = new StylerOptions
+            {
+                KeepOriginalElementFormat = true,
+                RemoveEndingTagOfEmptyElement = false,
+                IndentSize = 2,
+                IndentWithTabs = false
+            };
+
+            var stylerService = new StylerService(options, new XamlLanguageOptions { IsFormatable = true });
+
+            var input = string.Join(Environment.NewLine,
+                "<Root>",
+                "  <Button />",
+                "  <TextBlock></TextBlock>",
+                "</Root>");
+
+            var expected = string.Join(Environment.NewLine,
+                "<Root>",
+                "  <Button />",
+                "  <TextBlock></TextBlock>",
+                "</Root>");
+
+            Assert.That(stylerService.StyleDocument(input), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void KeepOriginalAttributeLineBreaksPreservesLayoutAndOrder()
+        {
+            var options = new StylerOptions
+            {
+                KeepOriginalAttributeLineBreaks = true,
+                EnableAttributeReordering = true,
+                IndentSize = 2,
+                IndentWithTabs = false
+            };
+
+            var stylerService = new StylerService(options, new XamlLanguageOptions { IsFormatable = true });
+
+            var input = string.Join(Environment.NewLine,
+                "<Root>",
+                "  <Button Width=\"20\"",
+                "          Height=\"10\" Margin=\"1\"",
+                "          Padding=\"2\" />",
+                "</Root>");
+
+            var expected = string.Join(Environment.NewLine,
+                "<Root>",
+                "  <Button Width=\"20\"",
+                "    Height=\"10\" Margin=\"1\"",
+                "    Padding=\"2\" />",
+                "</Root>");
+
+            Assert.That(stylerService.StyleDocument(input), Is.EqualTo(expected));
+        }
+    }
+}

--- a/src/XamlStyler/DocumentProcessors/ElementDocumentProcessor.cs
+++ b/src/XamlStyler/DocumentProcessors/ElementDocumentProcessor.cs
@@ -1,4 +1,4 @@
-// (c) Xavalon. All rights reserved.
+﻿// (c) Xavalon. All rights reserved.
 
 using System;
 using System.Collections.Generic;
@@ -51,6 +51,14 @@ namespace Xavalon.XamlStyler.DocumentProcessors
             elementProcessContext.UpdateParentElementProcessStatus(ContentTypes.Mixed);
 
             var elementName = xmlReader.Name;
+
+            // Get original format info if available
+            OriginalFormatInfo originalFormatInfo = null;
+            if (elementProcessContext.OriginalFormatParser != null)
+            {
+                originalFormatInfo = elementProcessContext.OriginalFormatParser.GetNextFormatInfo(elementName);
+            }
+
             elementProcessContext.Push(
                 new ElementProcessStatus
                 {
@@ -58,7 +66,8 @@ namespace Xavalon.XamlStyler.DocumentProcessors
                     Name = elementName,
                     ContentType = ContentTypes.None,
                     IsMultlineStartTag = false,
-                    IsPreservingSpace = elementProcessContext.Current.IsPreservingSpace
+                    IsPreservingSpace = elementProcessContext.Current.IsPreservingSpace,
+                    OriginalFormatInfo = originalFormatInfo
                 });
 
             var currentIndentString = this.indentService.GetIndentString(xmlReader.Depth);
@@ -105,7 +114,8 @@ namespace Xavalon.XamlStyler.DocumentProcessors
                     output,
                     elementProcessContext,
                     isNoLineBreakElement,
-                    attributeIndetationString);
+                    attributeIndetationString,
+                    originalFormatInfo);
             }
 
             // Determine if to put ending bracket on new line.
@@ -141,7 +151,8 @@ namespace Xavalon.XamlStyler.DocumentProcessors
             StringBuilder output,
             ElementProcessContext elementProcessContext,
             bool isNoLineBreakElement,
-            string attributeIndentationString)
+            string attributeIndentationString,
+            OriginalFormatInfo originalFormatInfo)
         {
             var list = new List<AttributeInfo>(xmlReader.AttributeCount);
             var firstLineList = new List<AttributeInfo>(xmlReader.AttributeCount);
@@ -163,6 +174,13 @@ namespace Xavalon.XamlStyler.DocumentProcessors
                 {
                     elementProcessContext.Current.IsPreservingSpace = (xmlReader.Value == "preserve");
                 }
+            }
+
+            // If KeepOriginalAttributeLineBreaks is enabled and we have original format info, use it
+            if (this.options.KeepOriginalAttributeLineBreaks && originalFormatInfo != null)
+            {
+                this.ProcessAttributesWithOriginalLineBreaks(output, elementProcessContext, list, attributeIndentationString, originalFormatInfo);
+                return;
             }
 
             if (this.options.EnableAttributeReordering)
@@ -376,6 +394,40 @@ namespace Xavalon.XamlStyler.DocumentProcessors
         private bool IsNoLineBreakElement(string elementName)
         {
             return this.noNewLineElementsList.Contains(elementName);
+        }
+
+        /// <summary>
+        /// Processes attributes while preserving the original line breaks from the source XAML.
+        /// </summary>
+        private void ProcessAttributesWithOriginalLineBreaks(
+            StringBuilder output,
+            ElementProcessContext elementProcessContext,
+            List<AttributeInfo> attributeList,
+            string attributeIndentationString,
+            OriginalFormatInfo originalFormatInfo)
+        {
+            bool hasMultipleLines = originalFormatInfo.AttributeLineBreakIndices.Count > 0;
+
+            for (int i = 0; i < attributeList.Count; i++)
+            {
+                var attrInfo = attributeList[i];
+                bool shouldLineBreak = originalFormatInfo.AttributeLineBreakIndices.Contains(i);
+
+                if (shouldLineBreak)
+                {
+                    // Put this attribute on a new line
+                    output.Append(Environment.NewLine)
+                        .Append(this.indentService.Normalize(attributeIndentationString))
+                        .Append(this.attributeInfoFormatter.ToSingleLineString(attrInfo, xamlLanguageOptions));
+                }
+                else
+                {
+                    // Put this attribute on the same line
+                    output.Append(' ').Append(this.attributeInfoFormatter.ToSingleLineString(attrInfo, xamlLanguageOptions));
+                }
+            }
+
+            elementProcessContext.Current.IsMultlineStartTag = hasMultipleLines;
         }
     }
 }

--- a/src/XamlStyler/DocumentProcessors/ElementDocumentProcessor.cs
+++ b/src/XamlStyler/DocumentProcessors/ElementDocumentProcessor.cs
@@ -52,11 +52,14 @@ namespace Xavalon.XamlStyler.DocumentProcessors
 
             var elementName = xmlReader.Name;
 
+            var parentPathKey = elementProcessContext.Current.PathKey;
+            var pathKey = string.IsNullOrEmpty(parentPathKey) ? elementName : $"{parentPathKey}/{elementName}";
+
             // Get original format info if available
             OriginalFormatInfo originalFormatInfo = null;
             if (elementProcessContext.OriginalFormatParser != null)
             {
-                originalFormatInfo = elementProcessContext.OriginalFormatParser.GetNextFormatInfo(elementName);
+                originalFormatInfo = elementProcessContext.OriginalFormatParser.GetNextFormatInfo(elementName, pathKey);
             }
 
             elementProcessContext.Push(
@@ -64,6 +67,7 @@ namespace Xavalon.XamlStyler.DocumentProcessors
                 {
                     Parent = elementProcessContext.Current,
                     Name = elementName,
+                    PathKey = pathKey,
                     ContentType = ContentTypes.None,
                     IsMultlineStartTag = false,
                     IsPreservingSpace = elementProcessContext.Current.IsPreservingSpace,
@@ -176,7 +180,8 @@ namespace Xavalon.XamlStyler.DocumentProcessors
                 }
             }
 
-            // If KeepOriginalAttributeLineBreaks is enabled and we have original format info, use it
+            // If KeepOriginalAttributeLineBreaks is enabled and we have original format info, use it.
+            // This preserves original line breaks and bypasses attribute reordering.
             if (this.options.KeepOriginalAttributeLineBreaks && originalFormatInfo != null)
             {
                 this.ProcessAttributesWithOriginalLineBreaks(output, elementProcessContext, list, attributeIndentationString, originalFormatInfo);

--- a/src/XamlStyler/DocumentProcessors/ElementProcessContext.cs
+++ b/src/XamlStyler/DocumentProcessors/ElementProcessContext.cs
@@ -1,4 +1,4 @@
-// (c) Xavalon. All rights reserved.
+﻿// (c) Xavalon. All rights reserved.
 
 using System.Collections.Generic;
 using Xavalon.XamlStyler.Parser;
@@ -12,6 +12,11 @@ namespace Xavalon.XamlStyler.DocumentProcessors
         public int Count => this.elementProcessStatusStack.Count;
 
         public ElementProcessStatus Current => this.elementProcessStatusStack.Peek();
+
+        /// <summary>
+        /// Gets or sets the original format parser for preserving original formatting.
+        /// </summary>
+        public OriginalFormatParser OriginalFormatParser { get; set; }
 
         public ElementProcessContext()
         {

--- a/src/XamlStyler/DocumentProcessors/EndElementDocumentProcessor.cs
+++ b/src/XamlStyler/DocumentProcessors/EndElementDocumentProcessor.cs
@@ -1,4 +1,4 @@
-// (c) Xavalon. All rights reserved.
+﻿// (c) Xavalon. All rights reserved.
 
 using System;
 using System.Text;
@@ -35,10 +35,12 @@ namespace Xavalon.XamlStyler.DocumentProcessors
                 output.Append("</").Append(xmlReader.Name).Append(">");
             }
             else if ((elementProcessContext.Current.ContentType == ContentTypes.None)
-                && this.options.RemoveEndingTagOfEmptyElement)
+                && this.options.RemoveEndingTagOfEmptyElement
+                && !this.options.KeepOriginalElementFormat)
             {
                 // Shrink the current element, if it has no content.
                 // E.g., <Element>  </Element> => <Element />
+                // Skip this if KeepOriginalElementFormat is enabled to preserve the original style.
                 output = output.TrimEnd(' ', '\t', '\r', '\n');
 
                 int bracketIndex = output.LastIndexOf('>');
@@ -50,6 +52,14 @@ namespace Xavalon.XamlStyler.DocumentProcessors
                 {
                     output.Insert(bracketIndex, ' ');
                 }
+            }
+            else if ((elementProcessContext.Current.ContentType == ContentTypes.None)
+                && this.options.KeepOriginalElementFormat)
+            {
+                // Keep original element format: preserve the end tag for elements that originally had end tags.
+                // E.g., <Element></Element> stays as <Element></Element>
+                output = output.TrimEnd(' ', '\t', '\r', '\n');
+                output.Append("</").Append(xmlReader.Name).Append(">");
             }
             else if ((elementProcessContext.Current.ContentType == ContentTypes.SingleLineTextOnly)
                 && !elementProcessContext.Current.IsMultlineStartTag)

--- a/src/XamlStyler/DocumentProcessors/EndElementDocumentProcessor.cs
+++ b/src/XamlStyler/DocumentProcessors/EndElementDocumentProcessor.cs
@@ -34,32 +34,61 @@ namespace Xavalon.XamlStyler.DocumentProcessors
             {
                 output.Append("</").Append(xmlReader.Name).Append(">");
             }
-            else if ((elementProcessContext.Current.ContentType == ContentTypes.None)
-                && this.options.RemoveEndingTagOfEmptyElement
-                && !this.options.KeepOriginalElementFormat)
+            else if (elementProcessContext.Current.ContentType == ContentTypes.None)
             {
-                // Shrink the current element, if it has no content.
-                // E.g., <Element>  </Element> => <Element />
-                // Skip this if KeepOriginalElementFormat is enabled to preserve the original style.
-                output = output.TrimEnd(' ', '\t', '\r', '\n');
+                var originalFormatInfo = elementProcessContext.Current.OriginalFormatInfo;
 
-                int bracketIndex = output.LastIndexOf('>');
-                output.Insert(bracketIndex, '/');
-
-                if ((output[bracketIndex - 1] != '\t') 
-                    && (output[bracketIndex - 1] != ' ')
-                    && this.options.SpaceBeforeClosingSlash)
+                if (this.options.KeepOriginalElementFormat && originalFormatInfo != null)
                 {
-                    output.Insert(bracketIndex, ' ');
+                    if (originalFormatInfo.IsSelfClosing)
+                    {
+                        // Preserve original self-closing elements.
+                        output = output.TrimEnd(' ', '\t', '\r', '\n');
+
+                        int bracketIndex = output.LastIndexOf('>');
+                        output.Insert(bracketIndex, '/');
+
+                        if ((output[bracketIndex - 1] != '\t')
+                            && (output[bracketIndex - 1] != ' ')
+                            && this.options.SpaceBeforeClosingSlash)
+                        {
+                            output.Insert(bracketIndex, ' ');
+                        }
+                    }
+                    else
+                    {
+                        // Preserve original explicit end tags.
+                        output = output.TrimEnd(' ', '\t', '\r', '\n');
+                        output.Append("</").Append(xmlReader.Name).Append(">");
+                    }
                 }
-            }
-            else if ((elementProcessContext.Current.ContentType == ContentTypes.None)
-                && this.options.KeepOriginalElementFormat)
-            {
-                // Keep original element format: preserve the end tag for elements that originally had end tags.
-                // E.g., <Element></Element> stays as <Element></Element>
-                output = output.TrimEnd(' ', '\t', '\r', '\n');
-                output.Append("</").Append(xmlReader.Name).Append(">");
+                else if (this.options.RemoveEndingTagOfEmptyElement)
+                {
+                    // Shrink the current element, if it has no content.
+                    // E.g., <Element>  </Element> => <Element />
+                    output = output.TrimEnd(' ', '\t', '\r', '\n');
+
+                    int bracketIndex = output.LastIndexOf('>');
+                    output.Insert(bracketIndex, '/');
+
+                    if ((output[bracketIndex - 1] != '\t')
+                        && (output[bracketIndex - 1] != ' ')
+                        && this.options.SpaceBeforeClosingSlash)
+                    {
+                        output.Insert(bracketIndex, ' ');
+                    }
+                }
+                else
+                {
+                    string currentIndentString = this.indentService.GetIndentString(xmlReader.Depth);
+
+                    if (!output.IsNewLine())
+                    {
+                        output.Append(Environment.NewLine);
+                    }
+
+                    output.Append(currentIndentString).Append("</").Append(xmlReader.Name).Append(">");
+                }
             }
             else if ((elementProcessContext.Current.ContentType == ContentTypes.SingleLineTextOnly)
                 && !elementProcessContext.Current.IsMultlineStartTag)

--- a/src/XamlStyler/Options/DefaultSettings.json
+++ b/src/XamlStyler/Options/DefaultSettings.json
@@ -27,6 +27,8 @@
   "PutEndingBracketOnNewLine": false,
   "RemoveEndingTagOfEmptyElement": true,
   "SpaceBeforeClosingSlash": true,
+  "KeepOriginalElementFormat": false,
+  "KeepOriginalAttributeLineBreaks": false,
   "RootElementLineBreakRule": 0,
   "ReorderVSM": 2,
   "ReorderGridChildren": false,

--- a/src/XamlStyler/Options/IStylerOptions.cs
+++ b/src/XamlStyler/Options/IStylerOptions.cs
@@ -1,4 +1,4 @@
-// (c) Xavalon. All rights reserved.
+﻿// (c) Xavalon. All rights reserved.
 
 using System.Diagnostics.CodeAnalysis;
 using Xavalon.XamlStyler.DocumentManipulation;
@@ -66,6 +66,10 @@ namespace Xavalon.XamlStyler.Options
         bool RemoveEndingTagOfEmptyElement { get; set; }
 
         bool SpaceBeforeClosingSlash { get; set; }
+
+        bool KeepOriginalElementFormat { get; set; }
+
+        bool KeepOriginalAttributeLineBreaks { get; set; }
 
         LineBreakRule RootElementLineBreakRule { get; set; }
 

--- a/src/XamlStyler/Options/StylerOptions.cs
+++ b/src/XamlStyler/Options/StylerOptions.cs
@@ -201,6 +201,20 @@ namespace Xavalon.XamlStyler.Options
         public bool SpaceBeforeClosingSlash { get; set; }
 
         [Category("Element Formatting")]
+        [DisplayName("Keep original element format")]
+        [JsonProperty("KeepOriginalElementFormat", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [Description("Defines whether to preserve the original element format. When true, self-closing elements will remain self-closing and elements with explicit end tags will keep their end tags.\r\n\r\nDefault Value: false")]
+        [DefaultValue(false)]
+        public bool KeepOriginalElementFormat { get; set; }
+
+        [Category("Element Formatting")]
+        [DisplayName("Keep original attribute line breaks")]
+        [JsonProperty("KeepOriginalAttributeLineBreaks", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [Description("Defines whether to preserve the original attribute line breaks. When true, attributes that were on separate lines will remain on separate lines, and attributes on the same line will remain together.\r\n\r\nDefault Value: false")]
+        [DefaultValue(false)]
+        public bool KeepOriginalAttributeLineBreaks { get; set; }
+
+        [Category("Element Formatting")]
         [DisplayName("Root element line breaks between attributes")]
         [JsonProperty("RootElementLineBreakRule", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         [Description("Defines whether attributes of the document root element are broken into multiple lines.\r\n\r\nDefault Value: Default (use same rules as other elements)")]

--- a/src/XamlStyler/Options/StylerOptions.cs
+++ b/src/XamlStyler/Options/StylerOptions.cs
@@ -203,14 +203,14 @@ namespace Xavalon.XamlStyler.Options
         [Category("Element Formatting")]
         [DisplayName("Keep original element format")]
         [JsonProperty("KeepOriginalElementFormat", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        [Description("Defines whether to preserve the original element format. When true, self-closing elements will remain self-closing and elements with explicit end tags will keep their end tags.\r\n\r\nDefault Value: false")]
+        [Description("Defines whether to preserve the original element format. When true, self-closing elements will remain self-closing and elements with explicit end tags will keep their end tags. This setting takes precedence over RemoveEndingTagOfEmptyElement when original formatting is available.\r\n\r\nDefault Value: false")]
         [DefaultValue(false)]
         public bool KeepOriginalElementFormat { get; set; }
 
         [Category("Element Formatting")]
         [DisplayName("Keep original attribute line breaks")]
         [JsonProperty("KeepOriginalAttributeLineBreaks", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        [Description("Defines whether to preserve the original attribute line breaks. When true, attributes that were on separate lines will remain on separate lines, and attributes on the same line will remain together.\r\n\r\nDefault Value: false")]
+        [Description("Defines whether to preserve the original attribute line breaks. When true, attributes that were on separate lines will remain on separate lines, and attributes on the same line will remain together. This setting preserves the original attribute layout and bypasses attribute reordering.\r\n\r\nDefault Value: false")]
         [DefaultValue(false)]
         public bool KeepOriginalAttributeLineBreaks { get; set; }
 

--- a/src/XamlStyler/Parser/ElementProcessStatus.cs
+++ b/src/XamlStyler/Parser/ElementProcessStatus.cs
@@ -34,6 +34,11 @@ namespace Xavalon.XamlStyler.Parser
         public string Name { get; set; }
 
         /// <summary>
+        /// Gets or sets the element path key used for original format matching.
+        /// </summary>
+        public string PathKey { get; set; }
+
+        /// <summary>
         /// Access to parent element
         /// </summary>
         public ElementProcessStatus Parent { get; set; }

--- a/src/XamlStyler/Parser/ElementProcessStatus.cs
+++ b/src/XamlStyler/Parser/ElementProcessStatus.cs
@@ -37,5 +37,10 @@ namespace Xavalon.XamlStyler.Parser
         /// Access to parent element
         /// </summary>
         public ElementProcessStatus Parent { get; set; }
+
+        /// <summary>
+        /// Gets or sets the original format info for this element.
+        /// </summary>
+        public OriginalFormatInfo OriginalFormatInfo { get; set; }
     }
 }

--- a/src/XamlStyler/Parser/OriginalFormatInfo.cs
+++ b/src/XamlStyler/Parser/OriginalFormatInfo.cs
@@ -1,0 +1,43 @@
+﻿// (c) Xavalon. All rights reserved.
+
+using System.Collections.Generic;
+
+namespace Xavalon.XamlStyler.Parser
+{
+    /// <summary>
+    /// Stores information about the original format of an element in the source XAML.
+    /// </summary>
+    public class OriginalFormatInfo
+    {
+        /// <summary>
+        /// Gets or sets the element name.
+        /// </summary>
+        public string ElementName { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the element was originally a self-closing element (e.g., &lt;Button /&gt;).
+        /// </summary>
+        public bool IsSelfClosing { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of attribute indices that had line breaks before them.
+        /// Index 0 means the first attribute had a line break before it (i.e., not on the same line as element name).
+        /// </summary>
+        public HashSet<int> AttributeLineBreakIndices { get; set; } = new HashSet<int>();
+
+        /// <summary>
+        /// Gets or sets the total number of attributes.
+        /// </summary>
+        public int AttributeCount { get; set; }
+
+        /// <summary>
+        /// Gets the start line number in the original source.
+        /// </summary>
+        public int StartLine { get; set; }
+
+        /// <summary>
+        /// Gets the start column number in the original source.
+        /// </summary>
+        public int StartColumn { get; set; }
+    }
+}

--- a/src/XamlStyler/Parser/OriginalFormatParser.cs
+++ b/src/XamlStyler/Parser/OriginalFormatParser.cs
@@ -2,9 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Text.RegularExpressions;
-using System.Xml;
 
 namespace Xavalon.XamlStyler.Parser
 {
@@ -13,22 +10,31 @@ namespace Xavalon.XamlStyler.Parser
     /// </summary>
     public class OriginalFormatParser
     {
-        private readonly Dictionary<string, Queue<OriginalFormatInfo>> elementFormatInfos;
+        private readonly Dictionary<string, Queue<OriginalFormatInfo>> elementFormatInfosByPath;
+        private readonly Dictionary<string, Queue<OriginalFormatInfo>> elementFormatInfosByName;
 
         public OriginalFormatParser(string xamlSource)
         {
-            this.elementFormatInfos = new Dictionary<string, Queue<OriginalFormatInfo>>(StringComparer.Ordinal);
+            this.elementFormatInfosByPath = new Dictionary<string, Queue<OriginalFormatInfo>>(StringComparer.Ordinal);
+            this.elementFormatInfosByName = new Dictionary<string, Queue<OriginalFormatInfo>>(StringComparer.Ordinal);
             this.ParseOriginalFormat(xamlSource);
         }
 
         /// <summary>
         /// Gets the next format info for the specified element name.
         /// </summary>
-        public OriginalFormatInfo GetNextFormatInfo(string elementName)
+        public OriginalFormatInfo GetNextFormatInfo(string elementName, string pathKey)
         {
-            if (this.elementFormatInfos.TryGetValue(elementName, out var queue) && queue.Count > 0)
+            if (!string.IsNullOrEmpty(pathKey)
+                && this.elementFormatInfosByPath.TryGetValue(pathKey, out var pathQueue)
+                && pathQueue.Count > 0)
             {
-                return queue.Dequeue();
+                return pathQueue.Dequeue();
+            }
+
+            if (this.elementFormatInfosByName.TryGetValue(elementName, out var nameQueue) && nameQueue.Count > 0)
+            {
+                return nameQueue.Dequeue();
             }
 
             return null;
@@ -36,102 +42,279 @@ namespace Xavalon.XamlStyler.Parser
 
         private void ParseOriginalFormat(string xamlSource)
         {
-            try
-            {
-                using (var reader = new StringReader(xamlSource))
-                {
-                    var settings = new XmlReaderSettings
-                    {
-                        IgnoreComments = false,
-                        IgnoreProcessingInstructions = false,
-                        IgnoreWhitespace = false
-                    };
-
-                    using (var xmlReader = XmlReader.Create(reader, settings))
-                    {
-                        // We need to track positions in the original source
-                        // XmlReader with IXmlLineInfo can give us line/column info
-                        var lineInfo = xmlReader as IXmlLineInfo;
-
-                        while (xmlReader.Read())
-                        {
-                            if (xmlReader.NodeType == XmlNodeType.Element)
-                            {
-                                var formatInfo = this.ParseElementFormatInfo(xmlReader, lineInfo, xamlSource);
-                                this.AddFormatInfo(formatInfo);
-                            }
-                        }
-                    }
-                }
-            }
-            catch (XmlException)
-            {
-                // If parsing fails, we'll just have no format info
-            }
-        }
-
-        private OriginalFormatInfo ParseElementFormatInfo(XmlReader xmlReader, IXmlLineInfo lineInfo, string xamlSource)
-        {
-            var formatInfo = new OriginalFormatInfo
-            {
-                ElementName = xmlReader.Name,
-                IsSelfClosing = xmlReader.IsEmptyElement,
-                AttributeCount = xmlReader.AttributeCount
-            };
-
-            if (lineInfo != null && lineInfo.HasLineInfo())
-            {
-                formatInfo.StartLine = lineInfo.LineNumber;
-                formatInfo.StartColumn = lineInfo.LinePosition;
-            }
-
-            // Parse attribute line breaks from the original source
-            if (xmlReader.HasAttributes)
-            {
-                this.ParseAttributeLineBreaks(xmlReader, lineInfo, formatInfo);
-            }
-
-            return formatInfo;
-        }
-
-        private void ParseAttributeLineBreaks(XmlReader xmlReader, IXmlLineInfo lineInfo, OriginalFormatInfo formatInfo)
-        {
-            if (lineInfo == null || !lineInfo.HasLineInfo())
+            if (string.IsNullOrEmpty(xamlSource))
             {
                 return;
             }
 
-            int elementLine = formatInfo.StartLine;
-            int previousAttributeLine = elementLine;
+            var pathStack = new Stack<string>();
+            int index = 0;
+
+            while (index < xamlSource.Length)
+            {
+                if (xamlSource[index] != '<')
+                {
+                    index++;
+                    continue;
+                }
+
+                if (this.StartsWith(xamlSource, index, "<!--"))
+                {
+                    index = this.SkipUntil(xamlSource, index + 4, "-->");
+                    continue;
+                }
+
+                if (this.StartsWith(xamlSource, index, "<?"))
+                {
+                    index = this.SkipUntil(xamlSource, index + 2, "?>");
+                    continue;
+                }
+
+                if (this.StartsWith(xamlSource, index, "<![CDATA["))
+                {
+                    index = this.SkipUntil(xamlSource, index + 9, "]]>" );
+                    continue;
+                }
+
+                if (this.StartsWith(xamlSource, index, "<!DOCTYPE"))
+                {
+                    index = this.SkipToChar(xamlSource, index + 9, '>') + 1;
+                    continue;
+                }
+
+                if (this.StartsWith(xamlSource, index, "</"))
+                {
+                    index += 2;
+                    this.ReadName(xamlSource, ref index);
+
+                    if (pathStack.Count > 0)
+                    {
+                        pathStack.Pop();
+                    }
+
+                    index = this.SkipToChar(xamlSource, index, '>') + 1;
+                    continue;
+                }
+
+                if (index + 1 < xamlSource.Length && xamlSource[index + 1] == '!')
+                {
+                    index = this.SkipToChar(xamlSource, index + 2, '>') + 1;
+                    continue;
+                }
+
+                // Start tag
+                index++;
+                string elementName = this.ReadName(xamlSource, ref index);
+                if (string.IsNullOrEmpty(elementName))
+                {
+                    continue;
+                }
+
+                string currentPathKey = pathStack.Count == 0
+                    ? elementName
+                    : $"{pathStack.Peek()}/{elementName}";
+
+                var formatInfo = new OriginalFormatInfo
+                {
+                    ElementName = elementName
+                };
+
+                this.ParseAttributesAndTagEnd(xamlSource, ref index, formatInfo, out bool isSelfClosing);
+                formatInfo.IsSelfClosing = isSelfClosing;
+
+                this.AddFormatInfo(formatInfo, currentPathKey, elementName);
+
+                if (!isSelfClosing)
+                {
+                    pathStack.Push(currentPathKey);
+                }
+            }
+        }
+
+        private void ParseAttributesAndTagEnd(string source, ref int index, OriginalFormatInfo formatInfo, out bool isSelfClosing)
+        {
+            isSelfClosing = false;
+            bool sawLineBreak = false;
             int attributeIndex = 0;
 
-            while (xmlReader.MoveToNextAttribute())
+            while (index < source.Length)
             {
-                int currentLine = lineInfo.LineNumber;
+                this.SkipWhitespace(source, ref index, ref sawLineBreak);
 
-                // If this attribute is on a different line than the previous one (or the element for first attr)
-                if (currentLine > previousAttributeLine)
+                if (index >= source.Length)
+                {
+                    break;
+                }
+
+                if (source[index] == '>')
+                {
+                    index++;
+                    break;
+                }
+
+                if (source[index] == '/' && (index + 1 < source.Length) && source[index + 1] == '>')
+                {
+                    isSelfClosing = true;
+                    index += 2;
+                    break;
+                }
+
+                string attributeName = this.ReadName(source, ref index);
+                if (string.IsNullOrEmpty(attributeName))
+                {
+                    index++;
+                    continue;
+                }
+
+                if (sawLineBreak)
                 {
                     formatInfo.AttributeLineBreakIndices.Add(attributeIndex);
                 }
 
-                previousAttributeLine = currentLine;
                 attributeIndex++;
+                sawLineBreak = false;
+
+                this.SkipWhitespace(source, ref index, ref sawLineBreak);
+
+                if (index < source.Length && source[index] == '=')
+                {
+                    index++;
+                }
+
+                this.SkipWhitespace(source, ref index, ref sawLineBreak);
+
+                if (index < source.Length && (source[index] == '"' || source[index] == '\''))
+                {
+                    char quote = source[index];
+                    index++;
+                    while (index < source.Length && source[index] != quote)
+                    {
+                        index++;
+                    }
+
+                    if (index < source.Length)
+                    {
+                        index++;
+                    }
+                }
+                else
+                {
+                    while (index < source.Length && !char.IsWhiteSpace(source[index]) && source[index] != '>' && source[index] != '/')
+                    {
+                        index++;
+                    }
+                }
             }
 
-            // Move back to element
-            xmlReader.MoveToElement();
+            formatInfo.AttributeCount = attributeIndex;
         }
 
-        private void AddFormatInfo(OriginalFormatInfo formatInfo)
+        private void AddFormatInfo(OriginalFormatInfo formatInfo, string pathKey, string elementName)
         {
-            if (!this.elementFormatInfos.TryGetValue(formatInfo.ElementName, out var queue))
+            if (!string.IsNullOrEmpty(pathKey))
             {
-                queue = new Queue<OriginalFormatInfo>();
-                this.elementFormatInfos[formatInfo.ElementName] = queue;
+                if (!this.elementFormatInfosByPath.TryGetValue(pathKey, out var pathQueue))
+                {
+                    pathQueue = new Queue<OriginalFormatInfo>();
+                    this.elementFormatInfosByPath[pathKey] = pathQueue;
+                }
+
+                pathQueue.Enqueue(formatInfo);
             }
 
-            queue.Enqueue(formatInfo);
+            if (!this.elementFormatInfosByName.TryGetValue(elementName, out var nameQueue))
+            {
+                nameQueue = new Queue<OriginalFormatInfo>();
+                this.elementFormatInfosByName[elementName] = nameQueue;
+            }
+
+            nameQueue.Enqueue(formatInfo);
+        }
+
+        private void SkipWhitespace(string source, ref int index, ref bool sawLineBreak)
+        {
+            while (index < source.Length && char.IsWhiteSpace(source[index]))
+            {
+                if (source[index] == '\r' || source[index] == '\n')
+                {
+                    sawLineBreak = true;
+
+                    if (source[index] == '\r' && (index + 1 < source.Length) && source[index + 1] == '\n')
+                    {
+                        index++;
+                    }
+                }
+
+                index++;
+            }
+        }
+
+        private string ReadName(string source, ref int index)
+        {
+            int start = index;
+
+            while (index < source.Length)
+            {
+                char c = source[index];
+                if (char.IsWhiteSpace(c) || c == '>' || c == '/' || c == '=' || c == '?')
+                {
+                    break;
+                }
+
+                index++;
+            }
+
+            if (index == start)
+            {
+                return string.Empty;
+            }
+
+            return source.Substring(start, index - start);
+        }
+
+        private bool StartsWith(string source, int index, string value)
+        {
+            if (index + value.Length > source.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < value.Length; i++)
+            {
+                if (source[index + i] != value[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private int SkipUntil(string source, int index, string token)
+        {
+            int tokenLength = token.Length;
+
+            while (index + tokenLength <= source.Length)
+            {
+                if (this.StartsWith(source, index, token))
+                {
+                    return index + tokenLength;
+                }
+
+                index++;
+            }
+
+            return source.Length;
+        }
+
+        private int SkipToChar(string source, int index, char target)
+        {
+            while (index < source.Length && source[index] != target)
+            {
+                index++;
+            }
+
+            return index;
         }
     }
 }

--- a/src/XamlStyler/Parser/OriginalFormatParser.cs
+++ b/src/XamlStyler/Parser/OriginalFormatParser.cs
@@ -1,0 +1,137 @@
+﻿// (c) Xavalon. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Xml;
+
+namespace Xavalon.XamlStyler.Parser
+{
+    /// <summary>
+    /// Parses the original XAML source to extract format metadata that is lost during XmlReader processing.
+    /// </summary>
+    public class OriginalFormatParser
+    {
+        private readonly Dictionary<string, Queue<OriginalFormatInfo>> elementFormatInfos;
+
+        public OriginalFormatParser(string xamlSource)
+        {
+            this.elementFormatInfos = new Dictionary<string, Queue<OriginalFormatInfo>>(StringComparer.Ordinal);
+            this.ParseOriginalFormat(xamlSource);
+        }
+
+        /// <summary>
+        /// Gets the next format info for the specified element name.
+        /// </summary>
+        public OriginalFormatInfo GetNextFormatInfo(string elementName)
+        {
+            if (this.elementFormatInfos.TryGetValue(elementName, out var queue) && queue.Count > 0)
+            {
+                return queue.Dequeue();
+            }
+
+            return null;
+        }
+
+        private void ParseOriginalFormat(string xamlSource)
+        {
+            try
+            {
+                using (var reader = new StringReader(xamlSource))
+                {
+                    var settings = new XmlReaderSettings
+                    {
+                        IgnoreComments = false,
+                        IgnoreProcessingInstructions = false,
+                        IgnoreWhitespace = false
+                    };
+
+                    using (var xmlReader = XmlReader.Create(reader, settings))
+                    {
+                        // We need to track positions in the original source
+                        // XmlReader with IXmlLineInfo can give us line/column info
+                        var lineInfo = xmlReader as IXmlLineInfo;
+
+                        while (xmlReader.Read())
+                        {
+                            if (xmlReader.NodeType == XmlNodeType.Element)
+                            {
+                                var formatInfo = this.ParseElementFormatInfo(xmlReader, lineInfo, xamlSource);
+                                this.AddFormatInfo(formatInfo);
+                            }
+                        }
+                    }
+                }
+            }
+            catch (XmlException)
+            {
+                // If parsing fails, we'll just have no format info
+            }
+        }
+
+        private OriginalFormatInfo ParseElementFormatInfo(XmlReader xmlReader, IXmlLineInfo lineInfo, string xamlSource)
+        {
+            var formatInfo = new OriginalFormatInfo
+            {
+                ElementName = xmlReader.Name,
+                IsSelfClosing = xmlReader.IsEmptyElement,
+                AttributeCount = xmlReader.AttributeCount
+            };
+
+            if (lineInfo != null && lineInfo.HasLineInfo())
+            {
+                formatInfo.StartLine = lineInfo.LineNumber;
+                formatInfo.StartColumn = lineInfo.LinePosition;
+            }
+
+            // Parse attribute line breaks from the original source
+            if (xmlReader.HasAttributes)
+            {
+                this.ParseAttributeLineBreaks(xmlReader, lineInfo, formatInfo);
+            }
+
+            return formatInfo;
+        }
+
+        private void ParseAttributeLineBreaks(XmlReader xmlReader, IXmlLineInfo lineInfo, OriginalFormatInfo formatInfo)
+        {
+            if (lineInfo == null || !lineInfo.HasLineInfo())
+            {
+                return;
+            }
+
+            int elementLine = formatInfo.StartLine;
+            int previousAttributeLine = elementLine;
+            int attributeIndex = 0;
+
+            while (xmlReader.MoveToNextAttribute())
+            {
+                int currentLine = lineInfo.LineNumber;
+
+                // If this attribute is on a different line than the previous one (or the element for first attr)
+                if (currentLine > previousAttributeLine)
+                {
+                    formatInfo.AttributeLineBreakIndices.Add(attributeIndex);
+                }
+
+                previousAttributeLine = currentLine;
+                attributeIndex++;
+            }
+
+            // Move back to element
+            xmlReader.MoveToElement();
+        }
+
+        private void AddFormatInfo(OriginalFormatInfo formatInfo)
+        {
+            if (!this.elementFormatInfos.TryGetValue(formatInfo.ElementName, out var queue))
+            {
+                queue = new Queue<OriginalFormatInfo>();
+                this.elementFormatInfos[formatInfo.ElementName] = queue;
+            }
+
+            queue.Enqueue(formatInfo);
+        }
+    }
+}

--- a/src/XamlStyler/StylerService.cs
+++ b/src/XamlStyler/StylerService.cs
@@ -15,6 +15,7 @@ using Xavalon.XamlStyler.MarkupExtensions.Formatter;
 using Xavalon.XamlStyler.MarkupExtensions.Parser;
 using Xavalon.XamlStyler.Model;
 using Xavalon.XamlStyler.Options;
+using Xavalon.XamlStyler.Parser;
 using Xavalon.XamlStyler.Services;
 
 namespace Xavalon.XamlStyler
@@ -68,8 +69,15 @@ namespace Xavalon.XamlStyler
                 // we can apply styler configuration.
                 this.ApplyOptions(ignoredNamespacesPrefixes, options.IgnoreDesignTimeReferencePrefix);
 
+                // Create original format parser if needed for preserving original format.
+                OriginalFormatParser originalFormatParser = null;
+                if (this.options.KeepOriginalElementFormat || this.options.KeepOriginalAttributeLineBreaks)
+                {
+                    originalFormatParser = new OriginalFormatParser(escapedDocument);
+                }
+
                 // Format it to a string.
-                var format = this.Format(manipulatedDocument);
+                var format = this.Format(manipulatedDocument, originalFormatParser);
 
                 // Restore escaped xml entity references.
                 xamlOutput = this.xmlEscapingService.UnescapeDocument(format);
@@ -153,7 +161,7 @@ namespace Xavalon.XamlStyler
             }
         }
 
-        private string Format(string xamlSource)
+        private string Format(string xamlSource, OriginalFormatParser originalFormatParser)
         {
             StringBuilder output = new StringBuilder();
 
@@ -161,7 +169,10 @@ namespace Xavalon.XamlStyler
             {
                 using (XmlReader xmlReader = XmlReader.Create(sourceReader))
                 {
-                    var elementProcessContext = new ElementProcessContext();
+                    var elementProcessContext = new ElementProcessContext
+                    {
+                        OriginalFormatParser = originalFormatParser
+                    };
 
                     while (xmlReader.Read())
                     {


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->

### Description:

Fixes #552

<!-- Please include a summary of your changes. Provide enough information so that others can review your pull request. -->

Summary:
- Add `KeepOriginalElementFormat` option to preserve self-closing vs explicit end-tag elements.
- Add `KeepOriginalAttributeLineBreaks` option to preserve original attribute line break layout (single-line vs multi-line).

### Checklist:
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] I have tested my changes by running the extension in VS2017
* [ ] I have tested my changes by running the extension in VS2019
* [x] I have tested my changes by running the extension in VS2022
* [ ] If changes to the [documentation](https://github.com/Xavalon/XamlStyler/wiki) are needed, I have noted this in the description above

The code in this PR was primarily generated by an LLM. Please review with extra scrutiny for any edge cases.